### PR TITLE
List all approved premises

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'cypress'
 import { resetStubs } from './wiremock'
 import auth from './integration_tests/mockApis/auth'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
+import premises from './integration_tests/mockApis/premises'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -22,6 +23,7 @@ export default defineConfig({
         reset: resetStubs,
         ...auth,
         ...tokenVerification,
+        ...premises,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/feature.env
+++ b/feature.env
@@ -7,3 +7,4 @@ API_CLIENT_ID=clientid
 API_CLIENT_SECRET=clientsecret
 SYSTEM_CLIENT_ID=clientid
 SYSTEM_CLIENT_SECRET=clientsecret
+APPROVED_PREMISES_API_URL=http://localhost:9091

--- a/integration_tests/.eslintrc
+++ b/integration_tests/.eslintrc
@@ -7,5 +7,12 @@
   "rules": {
     "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
     "no-only-tests/no-only-tests": "error"
+  },
+  "settings": {
+    "import/resolver": {
+      "typescript": {
+        "alwaysTryTypes": true
+      }
+    }
   }
 }

--- a/integration_tests/e2e/premises.cy.ts
+++ b/integration_tests/e2e/premises.cy.ts
@@ -1,0 +1,25 @@
+import premisesFactory from '../../server/testutils/factories/premises'
+import PremisesPage from '../pages/premises'
+
+context('Premises', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+  })
+
+  it('should list all premises', () => {
+    // Given there are premises in the database
+    const premises = premisesFactory.buildList(5)
+    cy.task('stubPremises', premises)
+
+    // And I am signed in
+    cy.signIn()
+
+    // When I visit the premises page
+    const page = PremisesPage.visit()
+
+    // Then I should see all of the premises listed
+    page.shouldShowPremises(premises)
+  })
+})

--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -1,0 +1,20 @@
+import type { Premises } from 'approved-premises'
+
+import { stubFor } from '../../wiremock'
+
+export default {
+  stubPremises: (premises: Array<Premises>) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: '/premises',
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: premises,
+      },
+    }),
+}

--- a/integration_tests/pages/premises.ts
+++ b/integration_tests/pages/premises.ts
@@ -1,0 +1,26 @@
+import type { Premises } from 'approved-premises'
+
+import Page from './page'
+
+export default class PremisesPage extends Page {
+  constructor() {
+    super('Premises')
+  }
+
+  static visit(): PremisesPage {
+    cy.visit('/premises')
+    return new PremisesPage()
+  }
+
+  shouldShowPremises(premises: Array<Premises>): void {
+    premises.forEach((item: Premises) => {
+      cy.contains(item.name)
+        .parent()
+        .within(() => {
+          cy.get('td').eq(0).contains(item.apCode)
+          cy.get('td').eq(1).contains(item.bedCount)
+          cy.get('td').eq(2).contains('View').should('have.attr', 'href', `/premises/${item.id}`)
+        })
+    })
+  }
+}

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -3,8 +3,9 @@
     "target": "es5",
     "noEmit": true,
     "lib": ["es5", "dom", "es2015.promise"],
-    "types": ["cypress"],
-    "esModuleInterop": true
+    "types": ["cypress", "approved-premises"],
+    "esModuleInterop": true,
+    "typeRoots": ["../server/@types", "../node_modules/@types"]
   },
   "include": ["**/*.ts"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.3.0",
+        "@golevelup/ts-jest": "^0.3.3",
         "@ministryofjustice/frontend": "^1.4.2",
         "agentkeepalive": "^4.2.1",
         "applicationinsights": "^2.3.3",
@@ -2075,6 +2076,11 @@
         "node": ">=14.0.0",
         "npm": ">=6.0.0"
       }
+    },
+    "node_modules/@golevelup/ts-jest": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@golevelup/ts-jest/-/ts-jest-0.3.3.tgz",
+      "integrity": "sha512-gut5EhD2S7W1p+C/IsUS1o0P5SHgxsN9TqHyRTjG+rfycniLNBfvIWZPEizpsTev/lR10/XOTpE0YicxPme2+Q=="
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -14530,6 +14536,11 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.3.0.tgz",
       "integrity": "sha512-1W0PZezq2rxlAssoWemi9gFRD8IQxvf0FPL5Km3TOmGHFG7ib0TbFBJ0yC7D/1NsxunjNTK6WjUXV8ao/mKZ5w=="
+    },
+    "@golevelup/ts-jest": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@golevelup/ts-jest/-/ts-jest-0.3.3.tgz",
+      "integrity": "sha512-gut5EhD2S7W1p+C/IsUS1o0P5SHgxsN9TqHyRTjG+rfycniLNBfvIWZPEizpsTev/lR10/XOTpE0YicxPme2+Q=="
     },
     "@hapi/hoek": {
       "version": "9.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@faker-js/faker": "^7.3.0",
         "@ministryofjustice/frontend": "^1.4.2",
         "agentkeepalive": "^4.2.1",
         "applicationinsights": "^2.3.3",
@@ -24,6 +25,7 @@
         "express": "^4.18.1",
         "express-prom-bundle": "^6.5.0",
         "express-session": "^1.17.3",
+        "fishery": "^2.2.2",
         "govuk-frontend": "^4.2.0",
         "helmet": "^5.1.0",
         "http-errors": "^2.0.0",
@@ -2063,6 +2065,15 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.3.0.tgz",
+      "integrity": "sha512-1W0PZezq2rxlAssoWemi9gFRD8IQxvf0FPL5Km3TOmGHFG7ib0TbFBJ0yC7D/1NsxunjNTK6WjUXV8ao/mKZ5w==",
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -6615,6 +6626,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/fishery": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/fishery/-/fishery-2.2.2.tgz",
+      "integrity": "sha512-jeU0nDhPHJkupmjX+r9niKgVMTBDB8X+U/pktoGHAiWOSyNlMd0HhmqnjrpjUOCDPJYaSSu4Ze16h6dZOKSp2w==",
+      "dependencies": {
+        "lodash.mergewith": "^4.6.2"
+      }
+    },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -9405,6 +9424,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -14502,6 +14526,11 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@faker-js/faker": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.3.0.tgz",
+      "integrity": "sha512-1W0PZezq2rxlAssoWemi9gFRD8IQxvf0FPL5Km3TOmGHFG7ib0TbFBJ0yC7D/1NsxunjNTK6WjUXV8ao/mKZ5w=="
+    },
     "@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -18032,6 +18061,14 @@
         "locate-path": "^2.0.0"
       }
     },
+    "fishery": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/fishery/-/fishery-2.2.2.tgz",
+      "integrity": "sha512-jeU0nDhPHJkupmjX+r9niKgVMTBDB8X+U/pktoGHAiWOSyNlMd0HhmqnjrpjUOCDPJYaSSu4Ze16h6dZOKSp2w==",
+      "requires": {
+        "lodash.mergewith": "^4.6.2"
+      }
+    },
     "flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -20106,6 +20143,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.once": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     ]
   },
   "dependencies": {
+    "@faker-js/faker": "^7.3.0",
     "@ministryofjustice/frontend": "^1.4.2",
     "agentkeepalive": "^4.2.1",
     "applicationinsights": "^2.3.3",
@@ -101,6 +102,7 @@
     "express": "^4.18.1",
     "express-prom-bundle": "^6.5.0",
     "express-session": "^1.17.3",
+    "fishery": "^2.2.2",
     "govuk-frontend": "^4.2.0",
     "helmet": "^5.1.0",
     "http-errors": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typecheck": "tsc && tsc -p integration_tests",
     "test": "jest",
     "test:e2e": "start-server-and-test start-feature http://localhost:3007/ping int-test",
+    "test:e2e:ui": "start-server-and-test start-feature:dev http://localhost:3007/ping int-test-ui",
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --config video=false",
     "int-test-ui": "cypress open",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.3.0",
+    "@golevelup/ts-jest": "^0.3.3",
     "@ministryofjustice/frontend": "^1.4.2",
     "agentkeepalive": "^4.2.1",
     "applicationinsights": "^2.3.3",

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -1,0 +1,14 @@
+declare module 'approved-premises' {
+  export type Premises = schemas['Premises']
+
+  export interface schemas {
+    Premises: {
+      id: string
+      name: string
+      apCode: string
+      postcode: string
+      bedCount: number
+      apAreaId: string
+    }
+  }
+}

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -1,6 +1,11 @@
 declare module 'approved-premises' {
   export type Premises = schemas['Premises']
 
+  export type TableCell = { text: string; attributes?: { [key: string]: string } } | { html: string }
+  export interface TableRow {
+    [index: number]: TableCell
+  }
+
   export interface schemas {
     Premises: {
       id: string

--- a/server/config.ts
+++ b/server/config.ts
@@ -67,6 +67,14 @@ export default {
       agent: new AgentConfig(Number(get('TOKEN_VERIFICATION_API_TIMEOUT_RESPONSE', 5000))),
       enabled: get('TOKEN_VERIFICATION_ENABLED', 'false') === 'true',
     },
+    approvedPremises: {
+      url: get('APPROVED_PREMISES_API_URL', 'http://localhost:9092', requiredInProduction),
+      timeout: {
+        response: 10000,
+        deadline: 10000,
+      },
+      agent: new AgentConfig(10000),
+    },
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
 }

--- a/server/controllers/premisesController.test.ts
+++ b/server/controllers/premisesController.test.ts
@@ -1,0 +1,30 @@
+import type { Request, Response, NextFunction } from 'express'
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
+import PremisesService from '../services/premisesService'
+import PremisesController from './premisesController'
+
+describe('PremisesController', () => {
+  const request: DeepMocked<Request> = createMock<Request>({})
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  let premisesController: PremisesController
+  let premisesService: DeepMocked<PremisesService>
+
+  beforeEach(() => {
+    premisesService = createMock<PremisesService>({})
+    premisesController = new PremisesController(premisesService)
+  })
+
+  describe('index', () => {
+    it('should return the table rows to the template', async () => {
+      premisesService.tableRows.mockResolvedValue([])
+
+      const requestHandler = premisesController.index()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('premises/index', { tableRows: [] })
+    })
+  })
+})

--- a/server/controllers/premisesController.ts
+++ b/server/controllers/premisesController.ts
@@ -1,0 +1,14 @@
+import type { Request, Response, RequestHandler } from 'express'
+
+import PremisesService from '../services/premisesService'
+
+export default class PremisesController {
+  constructor(private readonly premisesService: PremisesService) {}
+
+  index(): RequestHandler {
+    return async (_req: Request, res: Response) => {
+      const tableRows = await this.premisesService.tableRows()
+      return res.render('premises/index', { tableRows })
+    }
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -9,6 +9,7 @@ initialiseAppInsights()
 buildAppInsightsClient()
 
 import HmppsAuthClient from './hmppsAuthClient'
+import PremisesClient from './premisesClient'
 import { createRedisClient } from './redisClient'
 import TokenStore from './tokenStore'
 
@@ -16,8 +17,9 @@ type RestClientBuilder<T> = (token: string) => T
 
 export const dataAccess = () => ({
   hmppsAuthClient: new HmppsAuthClient(new TokenStore(createRedisClient({ legacyMode: false }))),
+  approvedPremisesClientBuilder: ((token: string) => new PremisesClient(token)) as RestClientBuilder<PremisesClient>,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>
 
-export { HmppsAuthClient, RestClientBuilder }
+export { PremisesClient, HmppsAuthClient, RestClientBuilder }

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -1,0 +1,38 @@
+import nock from 'nock'
+
+import type { Premises } from 'approved-premises'
+import PremisesClient from './premisesClient'
+import config from '../config'
+
+describe('PremisesClient', () => {
+  let fakeApprovedPremisesApi: nock.Scope
+  let premisesClient: PremisesClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    config.apis.approvedPremises.url = 'http://localhost:8080'
+    fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
+    premisesClient = new PremisesClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('getAllPremises', () => {
+    const premises: Premises[] = []
+
+    it('should get all premises', async () => {
+      fakeApprovedPremisesApi.get('/premises').matchHeader('authorization', `Bearer ${token}`).reply(200, premises)
+
+      const output = await premisesClient.getAllPremises()
+      expect(output).toEqual(premises)
+    })
+  })
+})

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -1,0 +1,15 @@
+import type { Premises } from 'approved-premises'
+import RestClient from './restClient'
+import config, { ApiConfig } from '../config'
+
+export default class PremisesClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('welcomeClient', config.apis.approvedPremises as ApiConfig, token)
+  }
+
+  async getAllPremises(): Promise<Array<Premises>> {
+    return (await this.restClient.get({ path: '/premises' })) as Array<Premises>
+  }
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -3,14 +3,19 @@ import { type RequestHandler, Router } from 'express'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import type { Services } from '../services'
 
+import PremisesController from '../controllers/premisesController'
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export default function routes(service: Services): Router {
+export default function routes(services: Services): Router {
   const router = Router()
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
+  const premisesController = new PremisesController(services.premisesService)
 
   get('/', (req, res, next) => {
     res.render('pages/index')
   })
+
+  get('/premises', premisesController.index())
 
   return router
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,16 +1,20 @@
 import { dataAccess } from '../data'
+
 import UserService from './userService'
+import PremisesService from './premisesService'
 
 export const services = () => {
-  const { hmppsAuthClient } = dataAccess()
+  const data = dataAccess()
 
-  const userService = new UserService(hmppsAuthClient)
+  const userService = new UserService(data.hmppsAuthClient)
+  const premisesService = new PremisesService(data.approvedPremisesClientBuilder)
 
   return {
     userService,
+    premisesService,
   }
 }
 
 export type Services = ReturnType<typeof services>
 
-export { UserService }
+export { UserService, PremisesService }

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -1,0 +1,77 @@
+import PremisesService from './premisesService'
+import PremisesClient from '../data/premisesClient'
+
+import premisesFactory from '../testutils/factories/premises'
+
+jest.mock('../data/premisesClient')
+
+describe('PremisesService', () => {
+  const premisesClient = new PremisesClient(null) as jest.Mocked<PremisesClient>
+  let service: PremisesService
+
+  const premisesClientFactory = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    premisesClientFactory.mockReturnValue(premisesClient)
+    service = new PremisesService(premisesClientFactory)
+  })
+
+  describe('tableRows', () => {
+    it('returns a table view of the premises', async () => {
+      const premises1 = premisesFactory.build({ name: 'XYZ' })
+      const premises2 = premisesFactory.build({ name: 'ABC' })
+      const premises3 = premisesFactory.build({ name: 'GHI' })
+
+      const premises = [premises1, premises2, premises3]
+      premisesClient.getAllPremises.mockResolvedValue(premises)
+
+      const rows = await service.tableRows()
+
+      expect(rows).toEqual([
+        [
+          {
+            text: premises2.name,
+          },
+          {
+            text: premises2.apCode,
+          },
+          {
+            text: premises2.bedCount.toString(),
+          },
+          {
+            html: `<a href="/premises/${premises2.id}">View<span class="govuk-visually-hidden">about ${premises2.name}</span></a>`,
+          },
+        ],
+        [
+          {
+            text: premises3.name,
+          },
+          {
+            text: premises3.apCode,
+          },
+          {
+            text: premises3.bedCount.toString(),
+          },
+          {
+            html: `<a href="/premises/${premises3.id}">View<span class="govuk-visually-hidden">about ${premises3.name}</span></a>`,
+          },
+        ],
+        [
+          {
+            text: premises1.name,
+          },
+          {
+            text: premises1.apCode,
+          },
+          {
+            text: premises1.bedCount.toString(),
+          },
+          {
+            html: `<a href="/premises/${premises1.id}">View<span class="govuk-visually-hidden">about ${premises1.name}</span></a>`,
+          },
+        ],
+      ])
+    })
+  })
+})

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -1,0 +1,33 @@
+import type { Premises, TableRow } from 'approved-premises'
+import type { RestClientBuilder, PremisesClient } from '../data'
+
+export default class PremisesService {
+  constructor(private readonly premisesClientFactory: RestClientBuilder<PremisesClient>) {}
+
+  async tableRows(): Promise<Array<TableRow>> {
+    // TODO: We need to do some more work on authentication to work
+    // out how to get this token, so let's stub for now
+    const token = 'FAKE_TOKEN'
+    const premisesClient = this.premisesClientFactory(token)
+    const premises = await premisesClient.getAllPremises()
+
+    return premises
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((p: Premises) => {
+        return [
+          {
+            text: p.name,
+          },
+          {
+            text: p.apCode,
+          },
+          {
+            text: p.bedCount.toString(),
+          },
+          {
+            html: `<a href="/premises/${p.id}">View<span class="govuk-visually-hidden">about ${p.name}</span></a>`,
+          },
+        ]
+      })
+  }
+}

--- a/server/testutils/factories/premises.ts
+++ b/server/testutils/factories/premises.ts
@@ -1,0 +1,13 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { Premises } from 'approved-premises'
+
+export default Factory.define<Premises>(() => ({
+  id: faker.datatype.uuid(),
+  name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
+  apCode: faker.random.alphaNumeric(5, { casing: 'upper' }),
+  postcode: faker.address.zipCode(),
+  bedCount: 50,
+  apAreaId: faker.random.alphaNumeric(2, { casing: 'upper' }),
+}))

--- a/server/views/premises/index.njk
+++ b/server/views/premises/index.njk
@@ -1,0 +1,34 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Home" %}
+
+{% block content %}
+
+	<main class="app-container govuk-body">
+		<h1>Premises</h1>
+
+		{{
+      govukTable({
+        captionClasses: "govuk-table__caption--m",
+        firstCellIsHeader: true,
+        head: [
+          {
+            text: "Name"
+          },
+          {
+            text: "Code"
+          },
+          {
+            text: "Bed Count"
+          },
+          {
+            html: '<span class="govuk-visually-hidden">Actions</span>'
+          }
+        ],
+        rows: tableRows
+      })
+    }}
+	</main>
+
+{% endblock %}


### PR DESCRIPTION
This is a simple end to end journey that fetches premises from the API, and presents them in a table view.

We have a client that fetches the data, a service that calls the client and marshals the data into the correct shape, and then a controller that calls the service.

This should be enough to demonstrate a pattern we can replicate across the app. There's definitely room for improvement / further optimisations along the way!

# Screenshot

![image](https://user-images.githubusercontent.com/109774/179801862-ee95255d-6e23-4252-a695-2ae9a51830e4.png)
