### PR TITLE
(445) View premises detail

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "trailingComma": "es5",
+  "trailingComma": "all",
   "singleQuote": true,
   "printWidth": 120,
   "semi": false,

--- a/integration_tests/e2e/premises.cy.ts
+++ b/integration_tests/e2e/premises.cy.ts
@@ -1,5 +1,6 @@
 import premisesFactory from '../../server/testutils/factories/premises'
-import PremisesPage from '../pages/premises'
+import PremisesListPage from '../pages/premisesList'
+import PremisesShowPage from '../pages/premisesShow'
 
 context('Premises', () => {
   beforeEach(() => {
@@ -17,9 +18,24 @@ context('Premises', () => {
     cy.signIn()
 
     // When I visit the premises page
-    const page = PremisesPage.visit()
+    const page = PremisesListPage.visit()
 
     // Then I should see all of the premises listed
     page.shouldShowPremises(premises)
+  })
+
+  it('should show a single premises', () => {
+    // Given there is a premises in the database
+    const premises = premisesFactory.build()
+    cy.task('subSinglePremises', premises)
+
+    // And I am signed in
+    cy.signIn()
+
+    // When I visit the premises page
+    const page = PremisesShowPage.visit(premises)
+
+    // Then I should see the premises details shown
+    page.shouldShowPremisesDetail()
   })
 })

--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -17,4 +17,19 @@ export default {
         jsonBody: premises,
       },
     }),
+
+  subSinglePremises: (premises: Premises) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/premises/${premises.id}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: premises,
+      },
+    }),
 }

--- a/integration_tests/pages/premisesList.ts
+++ b/integration_tests/pages/premisesList.ts
@@ -2,14 +2,14 @@ import type { Premises } from 'approved-premises'
 
 import Page from './page'
 
-export default class PremisesPage extends Page {
+export default class PremisesListPage extends Page {
   constructor() {
     super('Premises')
   }
 
-  static visit(): PremisesPage {
+  static visit(): PremisesListPage {
     cy.visit('/premises')
-    return new PremisesPage()
+    return new PremisesListPage()
   }
 
   shouldShowPremises(premises: Array<Premises>): void {

--- a/integration_tests/pages/premisesShow.ts
+++ b/integration_tests/pages/premisesShow.ts
@@ -1,0 +1,31 @@
+import type { Premises } from 'approved-premises'
+
+import Page from './page'
+
+export default class PremisesShowPage extends Page {
+  constructor(private readonly premises: Premises) {
+    super(premises.name)
+  }
+
+  static visit(premises: Premises): PremisesShowPage {
+    cy.visit(`/premises/${premises.id}`)
+    return new PremisesShowPage(premises)
+  }
+
+  shouldShowPremisesDetail(): void {
+    cy.get('.govuk-summary-list__key')
+      .contains('Code')
+      .siblings('.govuk-summary-list__value')
+      .should('contain', this.premises.apCode)
+
+    cy.get('.govuk-summary-list__key')
+      .contains('Postcode')
+      .siblings('.govuk-summary-list__value')
+      .should('contain', this.premises.postcode)
+
+    cy.get('.govuk-summary-list__key')
+      .contains('Number of Beds')
+      .siblings('.govuk-summary-list__value')
+      .should('contain', this.premises.bedCount)
+  }
+}

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -1,9 +1,39 @@
 declare module 'approved-premises' {
   export type Premises = schemas['Premises']
 
-  export type TableCell = { text: string; attributes?: { [key: string]: string } } | { html: string }
+  export interface HtmlAttributes {
+    [key: string]: string
+  }
+
+  export interface TextItem {
+    text: string
+  }
+
+  export interface HtmlItem {
+    html: string
+  }
+
+  export type TableCell = { text: string; attributes?: HtmlAttributes } | { html: string }
   export interface TableRow {
     [index: number]: TableCell
+  }
+
+  export interface SummaryListActionItem {
+    href: string
+    text: string
+    visuallyHiddenText: string
+  }
+
+  export interface SummaryListItem {
+    key: TextItem | HtmlItem
+    value: TextItem | HtmlItem
+    actions?: { items: Array<SummaryListActionItem> }
+  }
+
+  export interface SummaryList {
+    classes?: string
+    attributes?: HtmlAttributes
+    rows: Array<SummaryListItem>
   }
 
   export interface schemas {

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -8,6 +8,25 @@ declare module 'express-session' {
   }
 }
 
+declare module 'express' {
+  interface TypedRequest<T extends Query, U = Body> extends Express.Request {
+    body: U
+    params: T
+  }
+
+  interface TypedRequestHandler<T, U = Response> extends Express.RequestHandler {
+    (req: T, res: U, next: () => void): void
+  }
+
+  interface ShowParams {
+    id: string
+  }
+
+  type ShowRequest = TypedRequest<ShowParams>
+
+  type ShowRequestHandler = TypedRequestHandler<ShowParams>
+}
+
 export declare global {
   namespace Express {
     interface User {

--- a/server/controllers/premisesController.test.ts
+++ b/server/controllers/premisesController.test.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
+import type { SummaryListItem } from 'approved-premises'
 import PremisesService from '../services/premisesService'
 import PremisesController from './premisesController'
 
@@ -25,6 +26,22 @@ describe('PremisesController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('premises/index', { tableRows: [] })
+    })
+  })
+
+  describe('show', () => {
+    it('should return the premises detail to the template', async () => {
+      const premises = { name: 'Some premises', summaryList: { rows: [] as Array<SummaryListItem> } }
+      premisesService.getPremisesDetails.mockResolvedValue(premises)
+
+      request.params.id = 'some-uuid'
+
+      const requestHandler = premisesController.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('premises/show', { premises })
+
+      expect(premisesService.getPremisesDetails).toHaveBeenCalledWith('some-uuid')
     })
   })
 })

--- a/server/controllers/premisesController.ts
+++ b/server/controllers/premisesController.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, RequestHandler } from 'express'
+import type { Request, Response, RequestHandler, ShowRequest, ShowRequestHandler } from 'express'
 
 import PremisesService from '../services/premisesService'
 
@@ -9,6 +9,13 @@ export default class PremisesController {
     return async (_req: Request, res: Response) => {
       const tableRows = await this.premisesService.tableRows()
       return res.render('premises/index', { tableRows })
+    }
+  }
+
+  show(): ShowRequestHandler {
+    return async (req: ShowRequest, res: Response) => {
+      const premises = await this.premisesService.getPremisesDetails(req.params.id)
+      return res.render('premises/show', { premises })
     }
   }
 }

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock'
 
-import type { Premises } from 'approved-premises'
+import premisesFactory from '../testutils/factories/premises'
 import PremisesClient from './premisesClient'
 import config from '../config'
 
@@ -26,12 +26,26 @@ describe('PremisesClient', () => {
   })
 
   describe('getAllPremises', () => {
-    const premises: Premises[] = []
+    const premises = premisesFactory.buildList(5)
 
     it('should get all premises', async () => {
       fakeApprovedPremisesApi.get('/premises').matchHeader('authorization', `Bearer ${token}`).reply(200, premises)
 
       const output = await premisesClient.getAllPremises()
+      expect(output).toEqual(premises)
+    })
+  })
+
+  describe('getPremises', () => {
+    const premises = premisesFactory.build()
+
+    it('should get a single premises', async () => {
+      fakeApprovedPremisesApi
+        .get(`/premises/${premises.id}`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, premises)
+
+      const output = await premisesClient.getPremises(premises.id)
       expect(output).toEqual(premises)
     })
   })

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -12,4 +12,8 @@ export default class PremisesClient {
   async getAllPremises(): Promise<Array<Premises>> {
     return (await this.restClient.get({ path: '/premises' })) as Array<Premises>
   }
+
+  async getPremises(id: string): Promise<Premises> {
+    return (await this.restClient.get({ path: `/premises/${id}` })) as Premises
+  }
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -16,6 +16,7 @@ export default function routes(services: Services): Router {
   })
 
   get('/premises', premisesController.index())
+  get('/premises/:id', premisesController.show())
 
   return router
 }

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -74,4 +74,35 @@ describe('PremisesService', () => {
       ])
     })
   })
+
+  describe('getPremisesDetails', () => {
+    it('returns a title and a summary list for a given Premises ID', async () => {
+      const premises = premisesFactory.build({ name: 'Test', apCode: 'ABC', postcode: 'SW1A 1AA', bedCount: 50 })
+      premisesClient.getPremises.mockResolvedValue(premises)
+
+      const result = await service.getPremisesDetails(premises.id)
+
+      expect(result).toEqual({
+        name: 'Test',
+        summaryList: {
+          rows: [
+            {
+              key: { text: 'Code' },
+              value: { text: 'ABC' },
+            },
+            {
+              key: { text: 'Postcode' },
+              value: { text: 'SW1A 1AA' },
+            },
+            {
+              key: { text: 'Number of Beds' },
+              value: { text: '50' },
+            },
+          ],
+        },
+      })
+
+      expect(premisesClient.getPremises).toHaveBeenCalledWith(premises.id)
+    })
+  })
 })

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -1,33 +1,63 @@
-import type { Premises, TableRow } from 'approved-premises'
+import type { Premises, TableRow, SummaryList } from 'approved-premises'
 import type { RestClientBuilder, PremisesClient } from '../data'
 
 export default class PremisesService {
+  // TODO: We need to do some more work on authentication to work
+  // out how to get this token, so let's stub for now
+  token = 'FAKE_TOKEN'
+
   constructor(private readonly premisesClientFactory: RestClientBuilder<PremisesClient>) {}
 
   async tableRows(): Promise<Array<TableRow>> {
-    // TODO: We need to do some more work on authentication to work
-    // out how to get this token, so let's stub for now
-    const token = 'FAKE_TOKEN'
-    const premisesClient = this.premisesClientFactory(token)
+    const premisesClient = this.premisesClientFactory(this.token)
     const premises = await premisesClient.getAllPremises()
 
     return premises
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((p: Premises) => {
         return [
-          {
-            text: p.name,
-          },
-          {
-            text: p.apCode,
-          },
-          {
-            text: p.bedCount.toString(),
-          },
-          {
-            html: `<a href="/premises/${p.id}">View<span class="govuk-visually-hidden">about ${p.name}</span></a>`,
-          },
+          this.textValue(p.name),
+          this.textValue(p.apCode),
+          this.textValue(p.bedCount.toString()),
+          this.htmlValue(
+            `<a href="/premises/${p.id}">View<span class="govuk-visually-hidden">about ${p.name}</span></a>`,
+          ),
         ]
       })
+  }
+
+  async getPremisesDetails(id: string): Promise<{ name: string; summaryList: SummaryList }> {
+    const premisesClient = this.premisesClientFactory(this.token)
+    const premises = await premisesClient.getPremises(id)
+    const summaryList = await this.summaryListForPremises(premises)
+
+    return { name: premises.name, summaryList }
+  }
+
+  async summaryListForPremises(premises: Premises): Promise<SummaryList> {
+    return {
+      rows: [
+        {
+          key: this.textValue('Code'),
+          value: this.textValue(premises.apCode),
+        },
+        {
+          key: this.textValue('Postcode'),
+          value: this.textValue(premises.postcode),
+        },
+        {
+          key: this.textValue('Number of Beds'),
+          value: this.textValue(premises.bedCount.toString()),
+        },
+      ],
+    }
+  }
+
+  private textValue(value: string) {
+    return { text: value }
+  }
+
+  private htmlValue(value: string) {
+    return { html: value }
   }
 }

--- a/server/views/premises/show.njk
+++ b/server/views/premises/show.njk
@@ -1,0 +1,21 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + name %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+	{{ govukBackLink({
+		text: "Back",
+		href: "/premises"
+	}) }}
+
+	<h1>{{ premises.name }}</h1>
+
+	{{
+		govukSummaryList(premises.summaryList)
+	}}
+
+{% endblock %}


### PR DESCRIPTION
This adds a simple view page to premises to show some basic details about a given premises when accessing the `/premises/${id}` URL.

## Screenshot

![image](https://user-images.githubusercontent.com/109774/180006152-c61636de-7f28-4dd2-a0f4-c84f2b91debd.png)
