### PR TITLE
446 Add key worker select input

### DIFF
--- a/integration_tests/e2e/booking.cy.ts
+++ b/integration_tests/e2e/booking.cy.ts
@@ -16,7 +16,7 @@ context('Booking', () => {
       CRN: '1bee477b-462f-47c1-8f71-7835a76a2c42',
       arrivalDate: new Date(Date.UTC(2022, 5, 1, 0, 0, 0)),
       expectedDepartureDate: new Date(Date.UTC(2022, 5, 3, 0, 0, 0)),
-      keyWorker: 'Lizeth Hagenes',
+      keyWorker: 'Alex Evans',
     })
 
     const premises = premisesFactory.buildList(5)
@@ -45,7 +45,7 @@ context('Booking', () => {
       expect(requestBody.CRN).equal('1bee477b-462f-47c1-8f71-7835a76a2c42')
       expect(requestBody.arrivalDate).equal((booking.arrivalDate as Date).toISOString())
       expect(requestBody.expectedDepartureDate).equal((booking.expectedDepartureDate as Date).toISOString())
-      expect(requestBody.keyWorker).equal('Lizeth Hagenes')
+      expect(requestBody.keyWorker).equal('55126a32-0d27-4044-bc4e-e21c01632e56')
     })
   })
 })

--- a/integration_tests/pages/booking.ts
+++ b/integration_tests/pages/booking.ts
@@ -19,8 +19,12 @@ export default class BookingPage extends Page {
     cy.get('legend').should('contain', legendName)
   }
 
-  getByInputByIdAndEnterDetails(id: string, details: string): void {
+  getTextInputByIdAndEnterDetails(id: string, details: string): void {
     cy.get(`#${id}`).type(details)
+  }
+
+  getSelectInputByIdAndSelectAnEntry(id: string, entry: string): void {
+    cy.get(`#${id}`).select(entry)
   }
 
   arrivalDay(): PageElement {
@@ -53,7 +57,7 @@ export default class BookingPage extends Page {
 
   completeForm(booking: Booking): void {
     this.getLabel('CRN')
-    this.getByInputByIdAndEnterDetails('CRN', booking.CRN)
+    this.getTextInputByIdAndEnterDetails('CRN', booking.CRN)
 
     this.getLegend('What is the arrival date?')
     this.arrivalDay().type((booking.arrivalDate as Date).getDate().toString())
@@ -66,6 +70,6 @@ export default class BookingPage extends Page {
     this.expectedDepartureYear().type((booking.expectedDepartureDate as Date).getFullYear().toString())
 
     this.getLabel('Key Worker')
-    this.getByInputByIdAndEnterDetails('keyWorker', booking.keyWorker)
+    this.getSelectInputByIdAndSelectAnEntry('keyWorker', booking.keyWorker)
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "int-test-ui": "cypress open",
     "clean": "rm -rf dist build node_modules stylesheets",
     "api-stubs:create": "npx ts-node --transpile-only ./wiremock/stubApis.ts",
-    "api-stubs:reset": "npx ts-node --transpile-only ./wiremock/resetStubs.ts"
+    "api-stubs:reset": "npx ts-node --transpile-only ./wiremock/resetStubs.ts",
+    "start-test-wiremock": "docker-compose -f docker-compose-test.yml up -d"
   },
   "engines": {
     "node": "^18",

--- a/server/views/premises/booking/new.njk
+++ b/server/views/premises/booking/new.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -13,9 +14,9 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <form action="/premises/{{premisesId}}/booking/new" method="post">
-                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-            {{ govukInput({
+                {{ govukInput({
                 label: {
                     text: "CRN",
                     classes: "govuk-label--m"
@@ -25,7 +26,7 @@
                 name: "CRN"
             }) }}
 
-            {{ govukDateInput({
+                {{ govukDateInput({
                 id: "arrival-date",
                 namePrefix: "arrival",
                 fieldset: {
@@ -39,7 +40,7 @@
                 }
             }) }}
 
-            {{ govukDateInput({
+                {{ govukDateInput({
                 id: "expected-departure-date",
                 namePrefix: "expected-departure",
                 fieldset: {
@@ -53,19 +54,33 @@
                 }
             }) }}
 
-            {{ govukInput({
+                {{ govukSelect({
                 label: {
                     text: "Key Worker",
                     classes: "govuk-label--m"
                 },
                 classes: "govuk-input--width-20",
                 id: "keyWorker",
-                name: "keyWorker"
+                name: "keyWorker",
+                 items: [   
+                    {
+                    value: "bda42ec2-2435-47da-bb7f-54e90eda78b2",
+                    text: "George Frank"
+                    },
+                    {
+                    value: "55126a32-0d27-4044-bc4e-e21c01632e56",
+                    text: "Alex Evans"
+                    },
+                    {
+                    value: "cddb4be3-f0ef-4889-b987-61e1777ab17c",
+                    text: "Jo Longford"
+                    }
+                ]
             }) }}
 
-            {% from "govuk/components/button/macro.njk" import govukButton %}
+                {% from "govuk/components/button/macro.njk" import govukButton %}
 
-            {{ govukButton({
+                {{ govukButton({
                 text: "Submit"
             }) }}
             </form>


### PR DESCRIPTION
# Context
[From feedback on a previous PR](https://github.com/ministryofjustice/approved-premises-ui/pull/26#issuecomment-1191759262) I learned that the key worker input on the create a booking form will need to allow the user to select a key worker from a list of key workers and we will need to send their ID to the API.
[Trello Card](https://trello.com/c/o5ADpFax/446-create-a-booking)

# Changes in this PR
In order to get this input in sooner rather than later I have create an select input using mocked Key Worker names and hardcoded IDs.
In future the Key Worker names and their IDs will have to come from somewhere else but this should be easier to implement now we have the correct input in place. 

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/44123869/180973125-e4e7bf95-0d29-4f0e-94f8-3f862ad76918.png)

### After
![image](https://user-images.githubusercontent.com/44123869/180973386-daeccd9e-ec29-4063-8fef-fe4f3ae02b49.png)

