### PR TITLE
(503) Rework the date parser

### DIFF
--- a/integration_tests/e2e/arrivals.cy.ts
+++ b/integration_tests/e2e/arrivals.cy.ts
@@ -18,7 +18,10 @@ context('Arrivals', () => {
     // And I have a booking for a premises
     const premises = premisesFactory.build()
     const bookingId = 'some-uuid'
-    const arrival = arrivalFactory.build()
+    const arrival = arrivalFactory.build({
+      dateTime: new Date(2022, 1, 11).toISOString(),
+      expectedDeparture: new Date(2022, 11, 11).toISOString(),
+    })
 
     cy.task('stubSinglePremises', premises)
     cy.task('stubArrivalCreate', { premisesId: premises.id, bookingId, arrival })
@@ -32,19 +35,11 @@ context('Arrivals', () => {
       expect(requests).to.have.length(1)
       const requestBody = JSON.parse(requests[0].body)
 
-      const dateTime = arrival.dateTime as Date
-      const expectedDeparture = arrival.expectedDeparture as Date
-
-      const expectedDateTime = new Date(
-        Date.UTC(dateTime.getFullYear(), dateTime.getMonth(), dateTime.getDate(), 0, 0, 0),
-      )
-      const expectedExpectedDeparture = new Date(
-        Date.UTC(expectedDeparture.getFullYear(), expectedDeparture.getMonth(), expectedDeparture.getDate(), 0, 0, 0),
-      )
+      const { dateTime, expectedDeparture } = arrival
 
       expect(requestBody.notes).equal(arrival.notes)
-      expect(requestBody.dateTime).equal(expectedDateTime.toISOString())
-      expect(requestBody.expectedDeparture).equal(expectedExpectedDeparture.toISOString())
+      expect(requestBody.dateTime).equal(dateTime)
+      expect(requestBody.expectedDeparture).equal(expectedDeparture)
     })
 
     // And I should be redirected to the premises page

--- a/integration_tests/e2e/booking.cy.ts
+++ b/integration_tests/e2e/booking.cy.ts
@@ -14,8 +14,8 @@ context('Booking', () => {
   it('should show booking form', () => {
     const booking = bookingFactory.build({
       CRN: '1bee477b-462f-47c1-8f71-7835a76a2c42',
-      arrivalDate: new Date(Date.UTC(2022, 5, 1, 0, 0, 0)),
-      expectedDepartureDate: new Date(Date.UTC(2022, 5, 3, 0, 0, 0)),
+      arrivalDate: new Date(Date.UTC(2022, 5, 1, 0, 0, 0)).toISOString(),
+      expectedDepartureDate: new Date(Date.UTC(2022, 5, 3, 0, 0, 0)).toISOString(),
       keyWorker: 'Alex Evans',
     })
 
@@ -43,8 +43,8 @@ context('Booking', () => {
       const requestBody = JSON.parse(requests[0].body)
 
       expect(requestBody.CRN).equal('1bee477b-462f-47c1-8f71-7835a76a2c42')
-      expect(requestBody.arrivalDate).equal((booking.arrivalDate as Date).toISOString())
-      expect(requestBody.expectedDepartureDate).equal((booking.expectedDepartureDate as Date).toISOString())
+      expect(requestBody.arrivalDate).equal(booking.arrivalDate)
+      expect(requestBody.expectedDepartureDate).equal(booking.expectedDepartureDate)
       expect(requestBody.keyWorker).equal('55126a32-0d27-4044-bc4e-e21c01632e56')
     })
   })

--- a/integration_tests/pages/arrivalCreate.ts
+++ b/integration_tests/pages/arrivalCreate.ts
@@ -17,13 +17,16 @@ export default class ArrivalCreatePage extends Page {
 
     cy.log('arrival', arrival)
 
-    cy.get('input[name="dateTime-day"]').type(String((arrival.dateTime as Date).getDate()))
-    cy.get('input[name="dateTime-month"]').type(String((arrival.dateTime as Date).getMonth() + 1))
-    cy.get('input[name="dateTime-year"]').type(String((arrival.dateTime as Date).getFullYear()))
+    const dateTime = new Date(Date.parse(arrival.dateTime))
+    const expectedDeparture = new Date(Date.parse(arrival.expectedDeparture))
 
-    cy.get('input[name="expectedDeparture-day"]').type(String((arrival.expectedDeparture as Date).getDate()))
-    cy.get('input[name="expectedDeparture-month"]').type(String((arrival.expectedDeparture as Date).getMonth() + 1))
-    cy.get('input[name="expectedDeparture-year"]').type(String((arrival.expectedDeparture as Date).getFullYear()))
+    cy.get('input[name="dateTime-day"]').type(String(dateTime.getDate()))
+    cy.get('input[name="dateTime-month"]').type(String(dateTime.getMonth() + 1))
+    cy.get('input[name="dateTime-year"]').type(String(dateTime.getFullYear()))
+
+    cy.get('input[name="expectedDeparture-day"]').type(String(expectedDeparture.getDate()))
+    cy.get('input[name="expectedDeparture-month"]').type(String(expectedDeparture.getMonth() + 1))
+    cy.get('input[name="expectedDeparture-year"]').type(String(expectedDeparture.getFullYear()))
 
     cy.get('textarea[name="notes"]').type(arrival.notes)
 

--- a/integration_tests/pages/booking.ts
+++ b/integration_tests/pages/booking.ts
@@ -28,27 +28,27 @@ export default class BookingPage extends Page {
   }
 
   arrivalDay(): PageElement {
-    return cy.get('#arrival-date-day')
+    return cy.get('#arrivalDate-day')
   }
 
   arrivalMonth(): PageElement {
-    return cy.get('#arrival-date-month')
+    return cy.get('#arrivalDate-month')
   }
 
   arrivalYear(): PageElement {
-    return cy.get('#arrival-date-year')
+    return cy.get('#arrivalDate-year')
   }
 
   expectedDepartureDay(): PageElement {
-    return cy.get('#expected-departure-date-day')
+    return cy.get('#expectedDepartureDate-day')
   }
 
   expectedDepartureMonth(): PageElement {
-    return cy.get('#expected-departure-date-month')
+    return cy.get('#expectedDepartureDate-month')
   }
 
   expectedDepartureYear(): PageElement {
-    return cy.get('#expected-departure-date-year')
+    return cy.get('#expectedDepartureDate-year')
   }
 
   clickSubmit(): void {

--- a/integration_tests/pages/booking.ts
+++ b/integration_tests/pages/booking.ts
@@ -60,14 +60,20 @@ export default class BookingPage extends Page {
     this.getTextInputByIdAndEnterDetails('CRN', booking.CRN)
 
     this.getLegend('What is the arrival date?')
-    this.arrivalDay().type((booking.arrivalDate as Date).getDate().toString())
-    this.arrivalMonth().type(`${(booking.arrivalDate as Date).getMonth() + 1}`)
-    this.arrivalYear().type((booking.arrivalDate as Date).getFullYear().toString())
+
+    const arrivalDate = new Date(Date.parse(booking.arrivalDate))
+
+    this.arrivalDay().type(arrivalDate.getDate().toString())
+    this.arrivalMonth().type(`${arrivalDate.getMonth() + 1}`)
+    this.arrivalYear().type(arrivalDate.getFullYear().toString())
 
     this.getLegend('What is the expected departure date?')
-    this.expectedDepartureDay().type((booking.expectedDepartureDate as Date).getDate().toString())
-    this.expectedDepartureMonth().type(`${(booking.expectedDepartureDate as Date).getMonth() + 1}`)
-    this.expectedDepartureYear().type((booking.expectedDepartureDate as Date).getFullYear().toString())
+
+    const expectedDepartureDate = new Date(Date.parse(booking.expectedDepartureDate))
+
+    this.expectedDepartureDay().type(expectedDepartureDate.getDate().toString())
+    this.expectedDepartureMonth().type(`${expectedDepartureDate.getMonth() + 1}`)
+    this.expectedDepartureYear().type(expectedDepartureDate.getFullYear().toString())
 
     this.getLabel('Key Worker')
     this.getSelectInputByIdAndSelectAnEntry('keyWorker', booking.keyWorker)

--- a/integration_tests/pages/premisesShow.ts
+++ b/integration_tests/pages/premisesShow.ts
@@ -31,12 +31,11 @@ export default class PremisesShowPage extends Page {
 
   shouldShowBookings(bookings: Array<Booking>): void {
     bookings.forEach((item: Booking) => {
+      const arrivalDate = new Date(Date.parse(item.arrivalDate))
       cy.contains(item.CRN)
         .parent()
         .within(() => {
-          cy.get('td')
-            .eq(0)
-            .contains((item.arrivalDate as Date).toLocaleDateString('en-GB'))
+          cy.get('td').eq(0).contains(arrivalDate.toLocaleDateString('en-GB'))
           cy.get('td')
             .eq(1)
             .contains('Manage')

--- a/integration_tests/pages/premisesShow.ts
+++ b/integration_tests/pages/premisesShow.ts
@@ -1,3 +1,5 @@
+import { parseISO } from 'date-fns'
+
 import type { Premises, Booking } from 'approved-premises'
 
 import Page from './page'
@@ -31,7 +33,7 @@ export default class PremisesShowPage extends Page {
 
   shouldShowBookings(bookings: Array<Booking>): void {
     bookings.forEach((item: Booking) => {
-      const arrivalDate = new Date(Date.parse(item.arrivalDate))
+      const arrivalDate = parseISO(item.arrivalDate)
       cy.contains(item.CRN)
         .parent()
         .within(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "connect-flash": "^0.1.1",
         "connect-redis": "^6.1.3",
         "csurf": "^1.11.0",
+        "date-fns": "^2.29.1",
         "dotenv": "^16.0.1",
         "eslint-plugin-no-only-tests": "^3.0.0",
         "express": "^4.18.1",
@@ -5164,10 +5165,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
-      "dev": true,
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.1.tgz",
+      "integrity": "sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw==",
       "engines": {
         "node": ">=0.11"
       },
@@ -16946,10 +16946,9 @@
       }
     },
     "date-fns": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
-      "dev": true
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.1.tgz",
+      "integrity": "sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw=="
     },
     "dateformat": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "connect-flash": "^0.1.1",
     "connect-redis": "^6.1.3",
     "csurf": "^1.11.0",
+    "date-fns": "^2.29.1",
     "dotenv": "^16.0.1",
     "eslint-plugin-no-only-tests": "^3.0.0",
     "express": "^4.18.1",

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -6,7 +6,7 @@ declare module 'approved-premises' {
   export type BookingDto = Omit<Booking, 'id'>
 
   export type ObjectWithDateParts<K extends string | number> = { [P in `${K}-${'year' | 'month' | 'day'}`]: string } & {
-    [P in K]?: Date
+    [P in K]?: string
   }
 
   export type ArrivalDto = Omit<Arrival, 'id' | 'bookingId'> &

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -60,15 +60,15 @@ declare module 'approved-premises' {
     Booking: {
       id: string
       CRN: string
-      arrivalDate: Date | string
-      expectedDepartureDate: Date | string
+      arrivalDate: string
+      expectedDepartureDate: string
       keyWorker: string
     }
     Arrival: {
       id: string
       bookingId: string
-      dateTime: Date | string
-      expectedDeparture: Date | string
+      dateTime: string
+      expectedDeparture: string
       notes: string
     }
   }

--- a/server/controllers/arrivalsController.test.ts
+++ b/server/controllers/arrivalsController.test.ts
@@ -55,8 +55,8 @@ describe('ArrivalsController', () => {
 
       const expectedArrival = {
         ...request.body,
-        dateTime: new Date(2022, 11, 11),
-        expectedDeparture: new Date(2022, 10, 12),
+        dateTime: new Date(2022, 11, 11).toISOString(),
+        expectedDeparture: new Date(2022, 10, 12).toISOString(),
       }
 
       expect(arrivalService.createArrival).toHaveBeenCalledWith(

--- a/server/controllers/arrivalsController.ts
+++ b/server/controllers/arrivalsController.ts
@@ -1,7 +1,7 @@
 import type { Response, Request, RequestHandler } from 'express'
 import type { Arrival, ArrivalDto } from 'approved-premises'
 
-import { convertDateInputsToDateObj } from '../utils/utils'
+import { convertDateInputsToIsoString } from '../utils/utils'
 import ArrivalService from '../services/arrivalService'
 
 export default class ArrivalsController {
@@ -22,8 +22,8 @@ export default class ArrivalsController {
 
       const arrival: Omit<Arrival, 'id' | 'bookingId'> = {
         ...body,
-        ...convertDateInputsToDateObj(body, 'dateTime'),
-        ...convertDateInputsToDateObj(body, 'expectedDeparture'),
+        ...convertDateInputsToIsoString(body, 'dateTime'),
+        ...convertDateInputsToIsoString(body, 'expectedDeparture'),
       }
 
       this.arrivalService.createArrival(premisesId, bookingId, arrival)

--- a/server/controllers/bookingsController.test.ts
+++ b/server/controllers/bookingsController.test.ts
@@ -6,7 +6,7 @@ import BookingsController from './bookingsController'
 import BookingFactory from '../testutils/factories/booking'
 
 describe('bookingsController', () => {
-  const request: DeepMocked<Request> = createMock<Request>({})
+  let request: DeepMocked<Request> = createMock<Request>({})
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
@@ -38,32 +38,29 @@ describe('bookingsController', () => {
       const mockFlash = jest.fn()
       const requestHandler = bookingController.create()
 
-      await requestHandler(
-        {
-          ...request,
-          params: { premisesId: 'premisesIdParam' },
-          body: {
-            CRN: 'CRN',
-            keyWorker: 'John Doe',
-            'arrival-day': '01',
-            'arrival-month': '02',
-            'arrival-year': '2022',
-            'expected-departure-day': '01',
-            'expected-departure-month': '02',
-            'expected-departure-year': '2023',
-          },
-          flash: mockFlash,
+      request = {
+        ...request,
+        params: { premisesId: 'premisesIdParam' },
+        body: {
+          CRN: 'CRN',
+          keyWorker: 'John Doe',
+          'arrivalDate-day': '01',
+          'arrivalDate-month': '02',
+          'arrivalDate-year': '2022',
+          'expectedDepartureDate-day': '01',
+          'expectedDepartureDate-month': '02',
+          'expectedDepartureDate-year': '2023',
         },
-        response,
-        next,
-      )
+        flash: mockFlash,
+      }
+
+      await requestHandler(request, response, next)
       expect(mockFlash).toHaveBeenCalledWith('info', 'Booking made successfully')
 
       expect(bookingService.postBooking).toHaveBeenCalledWith('premisesIdParam', {
-        CRN: 'CRN',
+        ...request.body,
         arrivalDate: '2022-02-01T00:00:00.000Z',
         expectedDepartureDate: '2023-02-01T00:00:00.000Z',
-        keyWorker: 'John Doe',
       })
 
       expect(response.redirect).toHaveBeenCalledWith('/premises')
@@ -77,32 +74,29 @@ describe('bookingsController', () => {
 
       const requestHandler = bookingController.create()
 
-      await requestHandler(
-        {
-          ...request,
-          params: { premisesId: 'premisesIdParam' },
-          body: {
-            CRN: '',
-            keyWorker: '',
-            'arrival-day': '',
-            'arrival-month': '',
-            'arrival-year': '',
-            'expected-departure-day': '',
-            'expected-departure-month': '',
-            'expected-departure-year': '',
-          },
-          flash: mockFlash,
+      request = {
+        ...request,
+        params: { premisesId: 'premisesIdParam' },
+        body: {
+          CRN: '',
+          keyWorker: '',
+          'arrivalDate-day': '',
+          'arrivalDate-month': '',
+          'arrivalDate-year': '',
+          'expectedDepartureDate-day': '',
+          'expectedDepartureDate-month': '',
+          'expectedDepartureDate-year': '',
         },
-        response,
-        next,
-      )
+        flash: mockFlash,
+      }
+
+      await requestHandler(request, response, next)
       expect(mockFlash).toHaveBeenCalledWith('info', 'Booking made successfully')
 
       expect(bookingService.postBooking).toHaveBeenCalledWith('premisesIdParam', {
-        CRN: '',
-        arrivalDate: '1899-12-31T00:00:00.000Z',
-        expectedDepartureDate: '1899-12-31T00:00:00.000Z',
-        keyWorker: '',
+        ...request.body,
+        arrivalDate: '',
+        expectedDepartureDate: '',
       })
 
       expect(response.redirect).toHaveBeenCalledWith('/premises')
@@ -115,33 +109,29 @@ describe('bookingsController', () => {
       const mockFlash = jest.fn()
 
       const requestHandler = bookingController.create()
-
-      await requestHandler(
-        {
-          ...request,
-          params: { premisesId: 'premisesIdParam' },
-          body: {
-            CRN: '££$%£$£',
-            keyWorker: '[]',
-            'arrival-day': 'monday',
-            'arrival-month': '££',
-            'arrival-year': 'lorem ipsum',
-            'expected-departure-day': 'foo',
-            'expected-departure-month': 'bar',
-            'expected-departure-year': 'b4z',
-          },
-          flash: mockFlash,
+      request = {
+        ...request,
+        params: { premisesId: 'premisesIdParam' },
+        body: {
+          CRN: '££$%£$£',
+          keyWorker: '[]',
+          'arrivalDate-day': 'monday',
+          'arrivalDate-month': '££',
+          'arrivalDate-year': 'lorem ipsum',
+          'expectedDepartureDate-day': 'foo',
+          'expectedDepartureDate-month': 'bar',
+          'expectedDepartureDate-year': 'b4z',
         },
-        response,
-        next,
-      )
+        flash: mockFlash,
+      }
+
+      await requestHandler(request, response, next)
       expect(mockFlash).toHaveBeenCalledWith('info', 'Booking made successfully')
 
       expect(bookingService.postBooking).toHaveBeenCalledWith('premisesIdParam', {
-        CRN: '££$%£$£',
-        arrivalDate: '1899-12-31T00:00:00.000Z',
-        expectedDepartureDate: '1899-12-31T00:00:00.000Z',
-        keyWorker: '[]',
+        ...request.body,
+        arrivalDate: 'lorem ipsum-££-ayT00:00:00.000Z',
+        expectedDepartureDate: 'b4z-ar-ooT00:00:00.000Z',
       })
 
       expect(response.redirect).toHaveBeenCalledWith('/premises')

--- a/server/data/arrivalClient.test.ts
+++ b/server/data/arrivalClient.test.ts
@@ -43,8 +43,8 @@ describe('PremisesClient', () => {
 
       expect(result).toEqual({
         ...arrival,
-        dateTime: (arrival.dateTime as Date).toISOString(),
-        expectedDeparture: (arrival.expectedDeparture as Date).toISOString(),
+        dateTime: arrival.dateTime,
+        expectedDeparture: arrival.expectedDeparture,
       })
       expect(nock.isDone()).toBeTruthy()
     })

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -44,8 +44,8 @@ describe('BookingClient', () => {
 
       expect(result).toEqual({
         ...booking,
-        arrivalDate: (booking.arrivalDate as Date).toISOString(),
-        expectedDepartureDate: (booking.expectedDepartureDate as Date).toISOString(),
+        arrivalDate: booking.arrivalDate,
+        expectedDepartureDate: booking.expectedDepartureDate,
       })
       expect(nock.isDone()).toBeTruthy()
     })
@@ -64,8 +64,8 @@ describe('BookingClient', () => {
       const expectedBookings = bookings.map(booking => {
         return {
           ...booking,
-          arrivalDate: (booking.arrivalDate as Date).toISOString(),
-          expectedDepartureDate: (booking.expectedDepartureDate as Date).toISOString(),
+          arrivalDate: booking.arrivalDate,
+          expectedDepartureDate: booking.expectedDepartureDate,
         }
       })
 

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -30,8 +30,8 @@ describe('BookingService', () => {
   describe('listOfBookingsForPremisesId', () => {
     it('should return table rows of bookings', async () => {
       const bookings = [
-        BookingFactory.build({ arrivalDate: new Date(2022, 10, 22) }),
-        BookingFactory.build({ arrivalDate: new Date(2022, 2, 11) }),
+        BookingFactory.build({ arrivalDate: new Date(2022, 10, 22).toISOString() }),
+        BookingFactory.build({ arrivalDate: new Date(2022, 2, 11).toISOString() }),
       ]
       const premisesId = 'some-uuid'
       bookingClient.allBookingsForPremisesId.mockResolvedValue(bookings)

--- a/server/testutils/factories/arrival.ts
+++ b/server/testutils/factories/arrival.ts
@@ -5,8 +5,8 @@ import type { Arrival } from 'approved-premises'
 
 export default Factory.define<Arrival>(() => ({
   id: faker.datatype.uuid(),
-  dateTime: faker.date.soon(),
+  dateTime: faker.date.soon().toISOString(),
   bookingId: faker.datatype.uuid(),
-  expectedDeparture: faker.date.future(),
+  expectedDeparture: faker.date.future().toISOString(),
   notes: faker.lorem.sentence(),
 }))

--- a/server/testutils/factories/booking.ts
+++ b/server/testutils/factories/booking.ts
@@ -5,8 +5,8 @@ import type { Booking } from 'approved-premises'
 
 export default Factory.define<Booking>(() => ({
   CRN: faker.datatype.uuid(),
-  arrivalDate: faker.date.soon(),
-  expectedDepartureDate: faker.date.future(),
+  arrivalDate: faker.date.soon().toISOString(),
+  expectedDepartureDate: faker.date.future().toISOString(),
   keyWorker: `${faker.name.firstName()} ${faker.name.lastName()}`,
   id: faker.datatype.uuid(),
 }))

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -2,7 +2,7 @@ import {
   convertDateString,
   convertToTitleCase,
   initialiseName,
-  convertDateInputsToDateObj,
+  convertDateInputsToIsoString,
   InvalidDateStringError,
 } from './utils'
 
@@ -35,10 +35,10 @@ describe('initialise name', () => {
   })
 })
 
-describe('convertDate', () => {
+describe('convertDateInputsToDateObj', () => {
   it('converts a date object', () => {
     interface MyObjectWithADate {
-      date?: Date
+      date?: string
       ['date-year']: string
       ['date-month']: string
       ['date-day']: string
@@ -49,14 +49,32 @@ describe('convertDate', () => {
       'date-day': '11',
     }
 
-    const result = convertDateInputsToDateObj(obj, 'date')
+    const result = convertDateInputsToIsoString(obj, 'date')
 
-    expect(result.date.toString()).toMatch('Dec 11 2022')
+    expect(result.date).toEqual(new Date(2022, 11, 11).toISOString())
   })
 
-  it('returns a date object when given empty strings as input', () => {
+  it('pads the months and days', () => {
     interface MyObjectWithADate {
-      date?: Date
+      date?: string
+      ['date-year']: string
+      ['date-month']: string
+      ['date-day']: string
+    }
+    const obj: MyObjectWithADate = {
+      'date-year': '2022',
+      'date-month': '1',
+      'date-day': '1',
+    }
+
+    const result = convertDateInputsToIsoString(obj, 'date')
+
+    expect(result.date).toEqual(new Date(2022, 0, 1).toISOString())
+  })
+
+  it('returns an empty string when given empty strings as input', () => {
+    interface MyObjectWithADate {
+      date?: string
       ['date-year']: string
       ['date-month']: string
       ['date-day']: string
@@ -67,14 +85,14 @@ describe('convertDate', () => {
       'date-day': '',
     }
 
-    const result = convertDateInputsToDateObj(obj, 'date')
+    const result = convertDateInputsToIsoString(obj, 'date')
 
-    expect(result.date.toString()).toMatch('Dec 31 1899')
+    expect(result.date).toEqual('')
   })
 
-  it('returns a date object when given invalid strings as input', () => {
+  it('returns an invalid ISO string when given invalid strings as input', () => {
     interface MyObjectWithADate {
-      date?: Date
+      date?: string
       ['date-year']: string
       ['date-month']: string
       ['date-day']: string
@@ -85,9 +103,9 @@ describe('convertDate', () => {
       'date-day': 'foo',
     }
 
-    const result = convertDateInputsToDateObj(obj, 'date')
+    const result = convertDateInputsToIsoString(obj, 'date')
 
-    expect(result.date.toString()).toMatch('Dec 31 1899')
+    expect(result.date.toString()).toEqual('twothousandtwentytwo-20-ooT00:00:00.000Z')
   })
 })
 

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -110,12 +110,6 @@ describe('convertDateInputsToDateObj', () => {
 })
 
 describe('convertDateString', () => {
-  it('returns the date object unmutated', () => {
-    const date = new Date(2022, 10, 11)
-
-    expect(convertDateString(date)).toEqual(date)
-  })
-
   it('converts a ISO8601 date string', () => {
     const date = '2022-11-11T00:00:00.000Z'
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,3 +1,4 @@
+import { parseISO } from 'date-fns'
 import type { ObjectWithDateParts } from 'approved-premises'
 
 const properCase = (word: string): string =>
@@ -33,17 +34,13 @@ export const initialiseName = (fullName?: string): string | null => {
  * @throws {InvalidDateStringError} If the string is not a valid ISO8601 datetime string
  */
 export const convertDateString = (date: string): Date => {
-  try {
-    const parsedDate = new Date(Date.parse(date))
+  const parsedDate = parseISO(date)
 
-    if (date === parsedDate.toISOString()) {
-      return parsedDate
-    }
-
-    throw new Error()
-  } catch (error) {
+  if (Number.isNaN(parsedDate.getTime())) {
     throw new InvalidDateStringError(`Invalid Date: ${date}`)
   }
+
+  return parsedDate
 }
 
 /**

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -52,22 +52,25 @@ export const convertDateString = (date: string | Date): Date => {
 
 /**
  * Converts input for a GDS date input https://design-system.service.gov.uk/components/date-input/
- * into a javascript date object
+ * into an ISO8601 date string
  * @param dateInputObj an object with date parts (i.e. `-month` `-day` `-year`), which come from a `govukDateInput`.
  * @param key the key that prefixes each item in the dateInputObj, also the name of the property which the date object will be returned in the return value.
  * @returns name converted to proper case.
  */
-export const convertDateInputsToDateObj = <K extends string | number>(dateInputObj: ObjectWithDateParts<K>, key: K) => {
-  const [day, month, year] = [
-    Number(dateInputObj[`${key}-day`]),
-    Number(dateInputObj[`${key}-month`]),
-    Number(dateInputObj[`${key}-year`]),
-  ]
-  const o: { [P in K]?: Date } = dateInputObj
+export const convertDateInputsToIsoString = <K extends string | number>(
+  dateInputObj: ObjectWithDateParts<K>,
+  key: K,
+) => {
+  const day = `0${dateInputObj[`${key}-day`]}`.slice(-2)
+  const month = `0${dateInputObj[`${key}-month`]}`.slice(-2)
+  const year = dateInputObj[`${key}-year`]
+
+  const o: { [P in K]?: string } = dateInputObj
   if (day && month && year) {
-    o[key] = new Date(Date.UTC(year, month - 1, day, 0, 0, 0))
+    o[key] = `${year}-${month}-${day}T00:00:00.000Z`
   } else {
-    o[key] = new Date(0, 0, 0)
+    o[key] = ''
   }
+
   return dateInputObj
 }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -27,16 +27,12 @@ export const initialiseName = (fullName?: string): string | null => {
 }
 
 /**
- * Converts an object that may be a Date object or an ISO8601 datetime string into a Javascript Date object.
- * @param date Either a Javascript Date object or an ISO8601 datetime string
+ * Converts an ISO8601 datetime string into a Javascript Date object.
+ * @param date An ISO8601 datetime string
  * @returns A Date object
  * @throws {InvalidDateStringError} If the string is not a valid ISO8601 datetime string
  */
-export const convertDateString = (date: string | Date): Date => {
-  if (date instanceof Date) {
-    return date
-  }
-
+export const convertDateString = (date: string): Date => {
   try {
     const parsedDate = new Date(Date.parse(date))
 

--- a/server/views/premises/bookings/new.njk
+++ b/server/views/premises/bookings/new.njk
@@ -28,8 +28,8 @@
                 }) }}
 
 				{{ govukDateInput({
-                    id: "arrival-date",
-                    namePrefix: "arrival",
+                    id: "arrivalDate",
+                    namePrefix: "arrivalDate",
                     fieldset: {
                     legend: {
                         text: "What is the arrival date?",
@@ -42,8 +42,8 @@
                 }) }}
 
 				{{ govukDateInput({
-                    id: "expected-departure-date",
-                    namePrefix: "expected-departure",
+                    id: "expectedDepartureDate",
+                    namePrefix: "expectedDepartureDate",
                     fieldset: {
                     legend: {
                         text: "What is the expected departure date?",


### PR DESCRIPTION
After some discussion, we've decided to make a best attempt to transform date parts into an ISO8601 date string, and then pass it to the API. If the string is invalid, we will return an error from to API.

With this in mind, I've also updated all the objects that currently return either a Date or an ISO string, and updated them to only expect a string. If we want to do any conversion when the data hits the frontend, we can do this in a more predictable way.