### PR TITLE
446 booking confirmation page

### DIFF
--- a/integration_tests/mockApis/booking.ts
+++ b/integration_tests/mockApis/booking.ts
@@ -17,6 +17,20 @@ export default {
         jsonBody: args.booking,
       },
     }),
+  stubBookingGet: (args: { premisesId: string; booking: Booking }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/premises/${args.premisesId}/bookings/${args.booking.id}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: args.booking,
+      },
+    }),
   stubBookingsForPremisesId: (args: { premisesId: string; bookings: Array<Booking> }) =>
     stubFor({
       request: {

--- a/integration_tests/pages/booking.ts
+++ b/integration_tests/pages/booking.ts
@@ -6,8 +6,8 @@ export default class BookingPage extends Page {
     super('Make a booking')
   }
 
-  static visit(): BookingPage {
-    cy.visit('/premises/premisesId/bookings/new')
+  static visit(premisesId: string): BookingPage {
+    cy.visit(`/premises/${premisesId}/bookings/new`)
     return new BookingPage()
   }
 

--- a/integration_tests/pages/booking.ts
+++ b/integration_tests/pages/booking.ts
@@ -59,6 +59,9 @@ export default class BookingPage extends Page {
     this.getLabel('CRN')
     this.getTextInputByIdAndEnterDetails('CRN', booking.CRN)
 
+    this.getLabel('Name')
+    this.getTextInputByIdAndEnterDetails('name', booking.name)
+
     this.getLegend('What is the arrival date?')
 
     const arrivalDate = new Date(Date.parse(booking.arrivalDate))

--- a/integration_tests/pages/bookingConfirmation.ts
+++ b/integration_tests/pages/bookingConfirmation.ts
@@ -1,0 +1,32 @@
+import parseISO from 'date-fns/parseISO'
+import type { Booking } from 'approved-premises'
+import Page from './page'
+
+export default class BookingConfirmationPage extends Page {
+  constructor() {
+    super('Booking complete')
+  }
+
+  static visit(premisesId: string, bookingId: string): BookingConfirmationPage {
+    cy.visit(`/premises/${premisesId}/bookings/${bookingId}/confirmation`)
+    return new BookingConfirmationPage()
+  }
+
+  assertDefinition(term: string, value: string): void {
+    cy.get('dt').should('contain', term)
+    cy.get('dd').should('contain', value)
+  }
+
+  verifyBookingIsVisible(booking: Booking): void {
+    cy.get('dl').within(() => {
+      this.assertDefinition('Name', booking.name)
+      this.assertDefinition('CRN', booking.CRN)
+      this.assertDefinition('Arrival date', parseISO(booking.arrivalDate).toLocaleDateString('en-GB'))
+      this.assertDefinition(
+        'Expected departure date',
+        parseISO(booking.expectedDepartureDate).toLocaleDateString('en-GB'),
+      )
+      this.assertDefinition('Key worker', booking.keyWorker)
+    })
+  }
+}

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -59,6 +59,7 @@ declare module 'approved-premises' {
     }
     Booking: {
       id: string
+      name: string
       CRN: string
       arrivalDate: string
       expectedDepartureDate: string

--- a/server/controllers/bookingsController.test.ts
+++ b/server/controllers/bookingsController.test.ts
@@ -129,4 +129,29 @@ describe('bookingsController', () => {
       expect(response.redirect).toHaveBeenCalledWith(`/premises/${premisesId}/bookings/${booking.id}/confirmation`)
     })
   })
+
+  describe('confirm', () => {
+    it('renders the form with the details from the booking that is requested', async () => {
+      const booking = BookingFactory.build({
+        arrivalDate: new Date('07/27/22').toISOString(),
+        expectedDepartureDate: new Date('07/28/22').toISOString(),
+      })
+      bookingService.getBooking.mockResolvedValue(booking)
+      const premisesId = 'premisesId'
+      const requestHandler = bookingController.confirm()
+
+      request = {
+        ...request,
+        params: {
+          premisesId,
+          bookingId: booking.id,
+        },
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(bookingService.getBooking).toHaveBeenCalledWith(premisesId, booking.id)
+      expect(response.render).toHaveBeenCalledWith('premises/bookings/confirm', booking)
+    })
+  })
 })

--- a/server/controllers/bookingsController.test.ts
+++ b/server/controllers/bookingsController.test.ts
@@ -23,10 +23,11 @@ describe('bookingsController', () => {
   describe('new', () => {
     it('should render the form', async () => {
       const requestHandler = bookingController.new()
-      requestHandler({ ...request, params: { premisesId: 'premisesIdParam' } }, response, next)
+      const premisesId = 'premisesId'
+      requestHandler({ ...request, params: { premisesId } }, response, next)
 
       expect(response.render).toHaveBeenCalledWith('premises/bookings/new', {
-        premisesId: 'premisesIdParam',
+        premisesId,
       })
     })
   })
@@ -35,12 +36,12 @@ describe('bookingsController', () => {
     it('given the expected form data, the posting of the booking is successful should redirect to the "premises" page', async () => {
       const booking = BookingFactory.build()
       bookingService.postBooking.mockResolvedValue(booking)
-      const mockFlash = jest.fn()
+      const premisesId = 'premisesId'
       const requestHandler = bookingController.create()
 
       request = {
         ...request,
-        params: { premisesId: 'premisesIdParam' },
+        params: { premisesId },
         body: {
           CRN: 'CRN',
           keyWorker: 'John Doe',
@@ -51,32 +52,28 @@ describe('bookingsController', () => {
           'expectedDepartureDate-month': '02',
           'expectedDepartureDate-year': '2023',
         },
-        flash: mockFlash,
       }
 
       await requestHandler(request, response, next)
-      expect(mockFlash).toHaveBeenCalledWith('info', 'Booking made successfully')
 
-      expect(bookingService.postBooking).toHaveBeenCalledWith('premisesIdParam', {
+      expect(bookingService.postBooking).toHaveBeenCalledWith(premisesId, {
         ...request.body,
         arrivalDate: '2022-02-01T00:00:00.000Z',
         expectedDepartureDate: '2023-02-01T00:00:00.000Z',
       })
 
-      expect(response.redirect).toHaveBeenCalledWith('/premises')
+      expect(response.redirect).toHaveBeenCalledWith(`/premises/${premisesId}/bookings/${booking.id}/confirmation`)
     })
 
     it('given the form is submitted with no data the posting of the booking is successful should redirect to the "premises" page', async () => {
       const booking = BookingFactory.build()
       bookingService.postBooking.mockResolvedValue(booking)
-
-      const mockFlash = jest.fn()
-
+      const premisesId = 'premisesId'
       const requestHandler = bookingController.create()
 
       request = {
         ...request,
-        params: { premisesId: 'premisesIdParam' },
+        params: { premisesId },
         body: {
           CRN: '',
           keyWorker: '',
@@ -87,31 +84,28 @@ describe('bookingsController', () => {
           'expectedDepartureDate-month': '',
           'expectedDepartureDate-year': '',
         },
-        flash: mockFlash,
       }
 
       await requestHandler(request, response, next)
-      expect(mockFlash).toHaveBeenCalledWith('info', 'Booking made successfully')
 
-      expect(bookingService.postBooking).toHaveBeenCalledWith('premisesIdParam', {
+      expect(bookingService.postBooking).toHaveBeenCalledWith(premisesId, {
         ...request.body,
         arrivalDate: '',
         expectedDepartureDate: '',
       })
 
-      expect(response.redirect).toHaveBeenCalledWith('/premises')
+      expect(response.redirect).toHaveBeenCalledWith(`/premises/${premisesId}/bookings/${booking.id}/confirmation`)
     })
 
     it('given the form is submitted with unexpected values the posting of the booking is successful should redirect to the "premises" page', async () => {
       const booking = BookingFactory.build()
       bookingService.postBooking.mockResolvedValue(booking)
-
-      const mockFlash = jest.fn()
-
+      const premisesId = 'premisesId'
       const requestHandler = bookingController.create()
+
       request = {
         ...request,
-        params: { premisesId: 'premisesIdParam' },
+        params: { premisesId },
         body: {
           CRN: '££$%£$£',
           keyWorker: '[]',
@@ -122,19 +116,17 @@ describe('bookingsController', () => {
           'expectedDepartureDate-month': 'bar',
           'expectedDepartureDate-year': 'b4z',
         },
-        flash: mockFlash,
       }
 
       await requestHandler(request, response, next)
-      expect(mockFlash).toHaveBeenCalledWith('info', 'Booking made successfully')
 
-      expect(bookingService.postBooking).toHaveBeenCalledWith('premisesIdParam', {
+      expect(bookingService.postBooking).toHaveBeenCalledWith(premisesId, {
         ...request.body,
         arrivalDate: 'lorem ipsum-££-ayT00:00:00.000Z',
         expectedDepartureDate: 'b4z-ar-ooT00:00:00.000Z',
       })
 
-      expect(response.redirect).toHaveBeenCalledWith('/premises')
+      expect(response.redirect).toHaveBeenCalledWith(`/premises/${premisesId}/bookings/${booking.id}/confirmation`)
     })
   })
 })

--- a/server/controllers/bookingsController.ts
+++ b/server/controllers/bookingsController.ts
@@ -30,4 +30,13 @@ export default class BookingsController {
       return res.redirect(`/premises/${premisesId}/bookings/${confirmedBooking.id}/confirmation`)
     }
   }
+
+  confirm(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, bookingId } = req.params
+      const booking = await this.bookingService.getBooking(premisesId, bookingId)
+
+      return res.render('premises/bookings/confirm', booking)
+    }
+  }
 }

--- a/server/controllers/bookingsController.ts
+++ b/server/controllers/bookingsController.ts
@@ -25,11 +25,9 @@ export default class BookingsController {
         ...convertDateInputsToIsoString(req.body, 'expectedDepartureDate'),
       }
 
-      await this.bookingService.postBooking(premisesId as string, booking)
+      const confirmedBooking = await this.bookingService.postBooking(premisesId as string, booking)
 
-      req.flash('info', 'Booking made successfully')
-
-      res.redirect(`/premises`)
+      return res.redirect(`/premises/${premisesId}/bookings/${confirmedBooking.id}/confirmation`)
     }
   }
 }

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -48,6 +48,22 @@ describe('BookingClient', () => {
     })
   })
 
+  describe('getBooking', () => {
+    it('should return the booking that has been requested', async () => {
+      const booking = BookingFactory.build()
+
+      fakeApprovedPremisesApi
+        .get(`/premises/premisesId/bookings/bookingId`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, booking)
+
+      const result = await bookingClient.getBooking('premisesId', 'bookingId')
+
+      expect(result).toEqual(booking)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+
   describe('allBookingsForPremisesId', () => {
     it('should return all bookings for a given premises ID', async () => {
       const bookings = BookingFactory.buildList(5)

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -33,6 +33,7 @@ describe('BookingClient', () => {
         expectedDepartureDate: booking.expectedDepartureDate.toString(),
         CRN: booking.CRN,
         keyWorker: booking.keyWorker,
+        name: booking.name,
       }
 
       fakeApprovedPremisesApi

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -42,11 +42,7 @@ describe('BookingClient', () => {
 
       const result = await bookingClient.postBooking(booking.id, payload)
 
-      expect(result).toEqual({
-        ...booking,
-        arrivalDate: booking.arrivalDate,
-        expectedDepartureDate: booking.expectedDepartureDate,
-      })
+      expect(result).toEqual(booking)
       expect(nock.isDone()).toBeTruthy()
     })
   })
@@ -61,15 +57,8 @@ describe('BookingClient', () => {
         .reply(200, bookings)
 
       const result = await bookingClient.allBookingsForPremisesId('some-uuid')
-      const expectedBookings = bookings.map(booking => {
-        return {
-          ...booking,
-          arrivalDate: booking.arrivalDate,
-          expectedDepartureDate: booking.expectedDepartureDate,
-        }
-      })
 
-      expect(result).toEqual(expectedBookings)
+      expect(result).toEqual(bookings)
       expect(nock.isDone()).toBeTruthy()
     })
   })

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -13,6 +13,10 @@ export default class BookingClient {
     return (await this.restClient.post({ path: `/premises/${premisesId}/bookings`, data })) as Booking
   }
 
+  async getBooking(premisesId: string, bookingId: string): Promise<Booking> {
+    return (await this.restClient.get({ path: `/premises/${premisesId}/bookings/${bookingId}` })) as Booking
+  }
+
   async allBookingsForPremisesId(premisesId: string): Promise<Array<Booking>> {
     return (await this.restClient.get({ path: `/premises/${premisesId}/bookings` })) as Array<Booking>
   }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -25,6 +25,7 @@ export default function routes(services: Services): Router {
 
   get('/premises/:premisesId/bookings/new', bookingsController.new())
   post('/premises/:premisesId/bookings', bookingsController.create())
+  get('/premises/:premisesId/bookings/:bookingId/confirmation', bookingsController.confirm())
 
   get('/premises/:premisesId/bookings/:bookingId/arrivals/new', arrivalsController.new())
   router.post('/premises/:premisesId/bookings/:bookingId/arrivals', arrivalsController.create())

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -27,6 +27,20 @@ describe('BookingService', () => {
     })
   })
 
+  describe('getBooking', () => {
+    it('on success returns the booking that has been requested', async () => {
+      const booking = BookingFactory.build({
+        arrivalDate: new Date(2022, 2, 11).toISOString(),
+        expectedDepartureDate: new Date(2022, 2, 12).toISOString(),
+      })
+
+      bookingClient.getBooking.mockResolvedValue(booking)
+
+      const retrievedBooking = await service.getBooking('premisesId', booking.id)
+      expect(retrievedBooking).toEqual({ ...booking, arrivalDate: '11/03/2022', expectedDepartureDate: '12/03/2022' })
+    })
+  })
+
   describe('listOfBookingsForPremisesId', () => {
     it('should return table rows of bookings', async () => {
       const bookings = [

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -1,3 +1,5 @@
+import parseISO from 'date-fns/parseISO'
+
 import type { Booking, BookingDto, TableRow } from 'approved-premises'
 import type { RestClientBuilder } from '../data'
 import BookingClient from '../data/bookingClient'
@@ -15,6 +17,21 @@ export default class BookingService {
     const confirmedBooking = await bookingClient.postBooking(premisesId, booking)
 
     return confirmedBooking
+  }
+
+  async getBooking(premisesId: string, bookingId: string): Promise<Booking> {
+    // TODO: We need to do some more work on authentication to work
+    // out how to get this token, so let's stub for now
+    const token = 'FAKE_TOKEN'
+    const bookingClient = this.bookingClientFactory(token)
+
+    const booking = await bookingClient.getBooking(premisesId, bookingId)
+
+    return {
+      ...booking,
+      arrivalDate: parseISO(booking.arrivalDate).toLocaleDateString('en-GB'),
+      expectedDepartureDate: parseISO(booking.expectedDepartureDate).toLocaleDateString('en-GB'),
+    }
   }
 
   async listOfBookingsForPremisesId(premisesId: string): Promise<Array<TableRow>> {

--- a/server/testutils/factories/booking.ts
+++ b/server/testutils/factories/booking.ts
@@ -8,5 +8,6 @@ export default Factory.define<Booking>(() => ({
   arrivalDate: faker.date.soon().toISOString(),
   expectedDepartureDate: faker.date.future().toISOString(),
   keyWorker: `${faker.name.firstName()} ${faker.name.lastName()}`,
+  name: `${faker.name.firstName()} ${faker.name.lastName()}`,
   id: faker.datatype.uuid(),
 }))

--- a/server/views/premises/bookings/confirm.njk
+++ b/server/views/premises/bookings/confirm.njk
@@ -1,0 +1,61 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Home" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ govukPanel({
+            titleText: "Booking complete"
+            }) }}
+            {{ govukSummaryList({
+                rows: [
+                   {
+                    key: {
+                        text: "Name"
+                    },
+                    value: {
+                        text: name
+                    }
+                    },
+                    {
+                    key: {
+                        text: "CRN"
+                    },
+                    value: {
+                        text: CRN
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Arrival date"
+                    },
+                    value: {
+                        text: arrivalDate
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Expected departure date"
+                    },
+                    value: {
+                        text: expectedDepartureDate
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Key worker"
+                    },
+                    value: {
+                        text: keyWorker
+                    }
+                    }
+                ]
+            }) }}
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/premises/bookings/new.njk
+++ b/server/views/premises/bookings/new.njk
@@ -11,13 +11,13 @@
 
 {% block content %}
 
-	<h1>Make a booking</h1>
-	<div class="govuk-grid-row">
-		<div class="govuk-grid-column-two-thirds">
-			<form action="/premises/{{premisesId}}/bookings" method="post">
-				<input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+    <h1>Make a booking</h1>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="/premises/{{premisesId}}/bookings" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-				{{ govukInput({
+                {{ govukInput({
                     label: {
                         text: "CRN",
                         classes: "govuk-label--m"
@@ -27,7 +27,17 @@
                     name: "CRN"
                 }) }}
 
-				{{ govukDateInput({
+                {{ govukInput({
+                    label: {
+                        text: "Name",
+                        classes: "govuk-label--m"
+                    },
+                    classes: "govuk-input--width-10",
+                    id: "name",
+                    name: "name"
+                }) }}
+
+                {{ govukDateInput({
                     id: "arrivalDate",
                     namePrefix: "arrivalDate",
                     fieldset: {
@@ -41,7 +51,7 @@
                     }
                 }) }}
 
-				{{ govukDateInput({
+                {{ govukDateInput({
                     id: "expectedDepartureDate",
                     namePrefix: "expectedDepartureDate",
                     fieldset: {
@@ -55,7 +65,7 @@
                     }
                 }) }}
 
-				{{ govukSelect({
+                {{ govukSelect({
                     label: {
                         text: "Key Worker",
                         classes: "govuk-label--m"
@@ -79,11 +89,10 @@
                     ]
                 }) }}
 
-
-				{{ govukButton({
+                {{ govukButton({
                     text: "Submit"
                 }) }}
-			</form>
-		</div>
-	</div>
+            </form>
+        </div>
+    </div>
 {% endblock %}

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -78,6 +78,22 @@ stubs.push(async () =>
 stubs.push(async () =>
   stubFor({
     request: {
+      method: 'GET',
+      urlPathPattern: `/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      body: JSON.stringify(bookingFactory.build()),
+    },
+  }),
+)
+
+stubs.push(async () =>
+  stubFor({
+    request: {
       method: 'POST',
       urlPathPattern:
         '/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/arrivals',


### PR DESCRIPTION
# Context
We need to be able to show users the booking they've just created so that they can confirm the details.
Previously we redirected them to a list of the premises but now we are taking them to a new booking confirmation screen.
[Trello ticket](https://trello.com/c/o5ADpFax/446-create-a-booking)

# Changes in this PR

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/44123869/181456494-6c8caae9-2229-447c-8f73-e080d6028ca8.png)
