### PR TITLE
Add name and CRN to Arrival type

### DIFF
--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -70,6 +70,8 @@ declare module 'approved-premises' {
       dateTime: string
       expectedDeparture: string
       notes: string
+      name: string
+      CRN: string
     }
   }
 }

--- a/server/data/arrivalClient.test.ts
+++ b/server/data/arrivalClient.test.ts
@@ -32,6 +32,8 @@ describe('PremisesClient', () => {
         dateTime: arrival.dateTime.toString(),
         expectedDeparture: arrival.expectedDeparture.toString(),
         notes: arrival.notes,
+        name: arrival.name,
+        CRN: arrival.CRN,
       }
 
       fakeApprovedPremisesApi

--- a/server/testutils/factories/arrival.ts
+++ b/server/testutils/factories/arrival.ts
@@ -9,4 +9,6 @@ export default Factory.define<Arrival>(() => ({
   bookingId: faker.datatype.uuid(),
   expectedDeparture: faker.date.future().toISOString(),
   notes: faker.lorem.sentence(),
+  name: `${faker.name.firstName()} ${faker.name.lastName()}`,
+  CRN: faker.datatype.uuid(),
 }))


### PR DESCRIPTION
# Context
An arrival needs to have a name and CRN attatched to it.
This should do the job 😅
[Trello ticket](https://trello.com/c/73Y1jvej/497-displaying-person-on-probations-name-against-a-booking-arrival)

