### PR TITLE
450 group bookings into types

### DIFF
--- a/integration_tests/e2e/booking.cy.ts
+++ b/integration_tests/e2e/booking.cy.ts
@@ -1,5 +1,5 @@
 import premisesFactory from '../../server/testutils/factories/premises'
-import bookingFactory from '../../server/testutils/factories/booking'
+import bookingDtoFactory from '../../server/testutils/factories/booking'
 import BookingPage from '../pages/booking'
 import Page from '../pages/page'
 import BookingConfirmation from '../pages/bookingConfirmation'
@@ -12,7 +12,7 @@ context('Booking', () => {
   })
 
   it('should show booking form', () => {
-    const booking = bookingFactory.build({
+    const booking = bookingDtoFactory.build({
       CRN: '1bee477b-462f-47c1-8f71-7835a76a2c42',
       arrivalDate: new Date(Date.UTC(2022, 5, 1, 0, 0, 0)).toISOString(),
       expectedDepartureDate: new Date(Date.UTC(2022, 5, 3, 0, 0, 0)).toISOString(),

--- a/integration_tests/e2e/premises.cy.ts
+++ b/integration_tests/e2e/premises.cy.ts
@@ -28,7 +28,16 @@ context('Premises', () => {
   it('should show a single premises', () => {
     // Given there is a premises in the database
     const premises = premisesFactory.build()
-    const bookings = bookingsFactory.buildList(5)
+    const bookingsArrivingToday = bookingsFactory.arrivingToday().buildList(2)
+    const bookingsLeavingToday = bookingsFactory.departingToday().buildList(2)
+    const bookingsArrivingSoon = bookingsFactory.arrivingSoon().buildList(5)
+    const bookingsDepartingSoon = bookingsFactory.departingSoon().buildList(5)
+    const bookings = [
+      ...bookingsArrivingToday,
+      ...bookingsLeavingToday,
+      ...bookingsArrivingSoon,
+      ...bookingsDepartingSoon,
+    ]
 
     cy.task('stubPremisesWithBookings', { premises, bookings })
 
@@ -42,6 +51,6 @@ context('Premises', () => {
     page.shouldShowPremisesDetail()
 
     // And I should see all the bookings for that premises listed
-    page.shouldShowBookings(bookings)
+    page.shouldShowBookings(bookingsArrivingToday, bookingsLeavingToday, bookingsArrivingSoon, bookingsDepartingSoon)
   })
 })

--- a/integration_tests/pages/premisesShow.ts
+++ b/integration_tests/pages/premisesShow.ts
@@ -31,13 +31,48 @@ export default class PremisesShowPage extends Page {
       .should('contain', this.premises.bedCount)
   }
 
-  shouldShowBookings(bookings: Array<Booking>): void {
+  shouldShowBookings(
+    bookingsArrivingToday: Array<Booking>,
+    bookingsLeavingToday: Array<Booking>,
+    bookingsArrivingSoon: Array<Booking>,
+    bookingsLeavingSoon: Array<Booking>,
+  ): void {
+    cy.get('a')
+      .contains('Arriving Today')
+      .click()
+      .then(() => {
+        this.tableShouldContainBookings(bookingsArrivingToday, 'arrival')
+      })
+
+    cy.get('a')
+      .contains('Departing Today')
+      .click()
+      .then(() => {
+        this.tableShouldContainBookings(bookingsLeavingToday, 'departure')
+      })
+
+    cy.get('a')
+      .contains('Upcoming Arrivals')
+      .click()
+      .then(() => {
+        this.tableShouldContainBookings(bookingsArrivingSoon, 'arrival')
+      })
+
+    cy.get('a')
+      .contains('Upcoming Departures')
+      .click()
+      .then(() => {
+        this.tableShouldContainBookings(bookingsLeavingSoon, 'departure')
+      })
+  }
+
+  private tableShouldContainBookings(bookings: Array<Booking>, type: 'arrival' | 'departure') {
     bookings.forEach((item: Booking) => {
-      const arrivalDate = parseISO(item.arrivalDate)
+      const date = type === 'arrival' ? parseISO(item.arrivalDate) : parseISO(item.expectedDepartureDate)
       cy.contains(item.CRN)
         .parent()
         .within(() => {
-          cy.get('td').eq(0).contains(arrivalDate.toLocaleDateString('en-GB'))
+          cy.get('td').eq(0).contains(date.toLocaleDateString('en-GB'))
           cy.get('td')
             .eq(1)
             .contains('Manage')

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -50,6 +50,9 @@ declare module 'approved-premises' {
     rows: Array<SummaryListItem>
   }
 
+  export type GroupedListofBookings = {
+    [K in 'arrivingToday' | 'departingToday' | 'upcomingArrivals' | 'upcomingDepartures']: Array<TableRow>
+  }
   export interface schemas {
     Premises: {
       id: string

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -3,7 +3,7 @@ declare module 'approved-premises' {
   export type Arrival = schemas['Arrival']
   export type Booking = schemas['Booking']
 
-  export type BookingDto = Omit<Booking, 'id'>
+  export type BookingDto = Omit<Booking, 'id' | 'status' | 'arrival'>
 
   export type ObjectWithDateParts<K extends string | number> = { [P in `${K}-${'year' | 'month' | 'day'}`]: string } & {
     [P in K]?: string
@@ -12,6 +12,8 @@ declare module 'approved-premises' {
   export type ArrivalDto = Omit<Arrival, 'id' | 'bookingId'> &
     ObjectWithDateParts<'dateTime'> &
     ObjectWithDateParts<'expectedDeparture'>
+
+  export type BookingStatus = 'arrived' | 'awaiting-arrival' | 'not-arrived' | 'departed' | 'cancelled'
 
   export interface HtmlAttributes {
     [key: string]: string
@@ -64,6 +66,8 @@ declare module 'approved-premises' {
       arrivalDate: string
       expectedDepartureDate: string
       keyWorker: string
+      status: BookingStatus
+      arrival?: Arrival
     }
     Arrival: {
       id: string

--- a/server/controllers/bookingsController.test.ts
+++ b/server/controllers/bookingsController.test.ts
@@ -3,7 +3,7 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
 import BookingService from '../services/bookingService'
 import BookingsController from './bookingsController'
-import BookingFactory from '../testutils/factories/booking'
+import bookingFactory from '../testutils/factories/booking'
 
 describe('bookingsController', () => {
   let request: DeepMocked<Request> = createMock<Request>({})
@@ -34,7 +34,7 @@ describe('bookingsController', () => {
 
   describe('create', () => {
     it('given the expected form data, the posting of the booking is successful should redirect to the "premises" page', async () => {
-      const booking = BookingFactory.build()
+      const booking = bookingFactory.build()
       bookingService.postBooking.mockResolvedValue(booking)
       const premisesId = 'premisesId'
       const requestHandler = bookingController.create()
@@ -66,7 +66,7 @@ describe('bookingsController', () => {
     })
 
     it('given the form is submitted with no data the posting of the booking is successful should redirect to the "premises" page', async () => {
-      const booking = BookingFactory.build()
+      const booking = bookingFactory.build()
       bookingService.postBooking.mockResolvedValue(booking)
       const premisesId = 'premisesId'
       const requestHandler = bookingController.create()
@@ -98,7 +98,7 @@ describe('bookingsController', () => {
     })
 
     it('given the form is submitted with unexpected values the posting of the booking is successful should redirect to the "premises" page', async () => {
-      const booking = BookingFactory.build()
+      const booking = bookingFactory.build()
       bookingService.postBooking.mockResolvedValue(booking)
       const premisesId = 'premisesId'
       const requestHandler = bookingController.create()
@@ -132,7 +132,7 @@ describe('bookingsController', () => {
 
   describe('confirm', () => {
     it('renders the form with the details from the booking that is requested', async () => {
-      const booking = BookingFactory.build({
+      const booking = bookingFactory.build({
         arrivalDate: new Date('07/27/22').toISOString(),
         expectedDepartureDate: new Date('07/28/22').toISOString(),
       })

--- a/server/controllers/premisesController.test.ts
+++ b/server/controllers/premisesController.test.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
-import type { SummaryListItem, TableRow } from 'approved-premises'
+import type { SummaryListItem, GroupedListofBookings } from 'approved-premises'
 import PremisesService from '../services/premisesService'
 import BookingService from '../services/bookingService'
 import PremisesController from './premisesController'
@@ -35,9 +35,9 @@ describe('PremisesController', () => {
   describe('show', () => {
     it('should return the premises detail to the template', async () => {
       const premises = { name: 'Some premises', summaryList: { rows: [] as Array<SummaryListItem> } }
-      const bookings = [] as Array<TableRow>
+      const bookings = createMock<GroupedListofBookings>()
       premisesService.getPremisesDetails.mockResolvedValue(premises)
-      bookingService.listOfBookingsForPremisesId.mockResolvedValue(bookings)
+      bookingService.groupedListOfBookingsForPremisesId.mockResolvedValue(bookings)
 
       request.params.id = 'some-uuid'
 
@@ -47,7 +47,7 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('premises/show', { premises, bookings })
 
       expect(premisesService.getPremisesDetails).toHaveBeenCalledWith('some-uuid')
-      expect(bookingService.listOfBookingsForPremisesId).toHaveBeenCalledWith('some-uuid')
+      expect(bookingService.groupedListOfBookingsForPremisesId).toHaveBeenCalledWith('some-uuid')
     })
   })
 })

--- a/server/controllers/premisesController.ts
+++ b/server/controllers/premisesController.ts
@@ -16,7 +16,7 @@ export default class PremisesController {
   show(): ShowRequestHandler {
     return async (req: ShowRequest, res: Response) => {
       const premises = await this.premisesService.getPremisesDetails(req.params.id)
-      const bookings = await this.bookingService.listOfBookingsForPremisesId(req.params.id)
+      const bookings = await this.bookingService.groupedListOfBookingsForPremisesId(req.params.id)
       return res.render('premises/show', { premises, bookings })
     }
   }

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -1,7 +1,8 @@
 import nock from 'nock'
 
 import BookingClient from './bookingClient'
-import BookingFactory from '../testutils/factories/booking'
+import bookingFactory from '../testutils/factories/booking'
+import bookingDtoFactory from '../testutils/factories/bookingDto'
 import config from '../config'
 
 describe('BookingClient', () => {
@@ -27,21 +28,21 @@ describe('BookingClient', () => {
 
   describe('postBooking', () => {
     it('should return the booking that has been posted', async () => {
-      const booking = BookingFactory.build()
-      const payload = {
-        arrivalDate: booking.arrivalDate.toString(),
-        expectedDepartureDate: booking.expectedDepartureDate.toString(),
+      const booking = bookingFactory.build()
+      const payload = bookingDtoFactory.build({
+        arrivalDate: booking.arrivalDate,
+        expectedDepartureDate: booking.expectedDepartureDate,
         CRN: booking.CRN,
         keyWorker: booking.keyWorker,
         name: booking.name,
-      }
+      })
 
       fakeApprovedPremisesApi
-        .post(`/premises/${booking.id}/bookings`)
+        .post(`/premises/some-uuid/bookings`)
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(201, booking)
 
-      const result = await bookingClient.postBooking(booking.id, payload)
+      const result = await bookingClient.postBooking('some-uuid', payload)
 
       expect(result).toEqual(booking)
       expect(nock.isDone()).toBeTruthy()
@@ -50,7 +51,7 @@ describe('BookingClient', () => {
 
   describe('getBooking', () => {
     it('should return the booking that has been requested', async () => {
-      const booking = BookingFactory.build()
+      const booking = bookingFactory.build()
 
       fakeApprovedPremisesApi
         .get(`/premises/premisesId/bookings/bookingId`)
@@ -66,7 +67,7 @@ describe('BookingClient', () => {
 
   describe('allBookingsForPremisesId', () => {
     it('should return all bookings for a given premises ID', async () => {
-      const bookings = BookingFactory.buildList(5)
+      const bookings = bookingFactory.buildList(5)
 
       fakeApprovedPremisesApi
         .get(`/premises/some-uuid/bookings`)

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -1,7 +1,8 @@
 import BookingService from './bookingService'
 import BookingClient from '../data/bookingClient'
 
-import BookingFactory from '../testutils/factories/booking'
+import bookingDtoFactory from '../testutils/factories/bookingDto'
+import bookingFactory from '../testutils/factories/booking'
 
 jest.mock('../data/bookingClient.ts')
 
@@ -19,10 +20,11 @@ describe('BookingService', () => {
 
   describe('postBooking', () => {
     it('on success returns the booking that has been posted', async () => {
-      const booking = BookingFactory.build()
+      const booking = bookingFactory.build()
+      const bookingDto = bookingDtoFactory.build()
       bookingClient.postBooking.mockResolvedValue(booking)
 
-      const postedBooking = await service.postBooking('premisesId', booking)
+      const postedBooking = await service.postBooking('premisesId', bookingDto)
       expect(postedBooking).toEqual(booking)
     })
   })
@@ -44,8 +46,8 @@ describe('BookingService', () => {
   describe('listOfBookingsForPremisesId', () => {
     it('should return table rows of bookings', async () => {
       const bookings = [
-        BookingFactory.build({ arrivalDate: new Date(2022, 10, 22).toISOString() }),
-        BookingFactory.build({ arrivalDate: new Date(2022, 2, 11).toISOString() }),
+        bookingFactory.build({ arrivalDate: new Date(2022, 10, 22).toISOString() }),
+        bookingFactory.build({ arrivalDate: new Date(2022, 2, 11).toISOString() }),
       ]
       const premisesId = 'some-uuid'
       bookingClient.allBookingsForPremisesId.mockResolvedValue(bookings)

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -44,14 +44,36 @@ describe('BookingService', () => {
   })
 
   describe('bookingsToTableRows', () => {
-    it('should convert bookings to table rows', () => {
+    it('should convert bookings to table rows with an arrival date', () => {
       const premisesId = 'some-uuid'
       const bookings = [
         bookingFactory.build({ arrivalDate: new Date(2022, 10, 22).toISOString() }),
         bookingFactory.build({ arrivalDate: new Date(2022, 2, 11).toISOString() }),
       ]
 
-      const results = service.bookingsToTableRows(bookings, premisesId)
+      const results = service.bookingsToTableRows(bookings, premisesId, 'arrival')
+
+      expect(results[0][0]).toEqual({ text: bookings[0].CRN })
+      expect(results[0][1]).toEqual({ text: '22/11/2022' })
+      expect(results[0][2]).toEqual({
+        html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[0].id}/arrivals/new`),
+      })
+
+      expect(results[1][0]).toEqual({ text: bookings[1].CRN })
+      expect(results[1][1]).toEqual({ text: '11/03/2022' })
+      expect(results[1][2]).toEqual({
+        html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[1].id}/arrivals/new`),
+      })
+    })
+
+    it('should convert bookings to table rows with a departute date', () => {
+      const premisesId = 'some-uuid'
+      const bookings = [
+        bookingFactory.build({ expectedDepartureDate: new Date(2022, 10, 22).toISOString() }),
+        bookingFactory.build({ expectedDepartureDate: new Date(2022, 2, 11).toISOString() }),
+      ]
+
+      const results = service.bookingsToTableRows(bookings, premisesId, 'departure')
 
       expect(results[0][0]).toEqual({ text: bookings[0].CRN })
       expect(results[0][1]).toEqual({ text: '22/11/2022' })
@@ -76,7 +98,7 @@ describe('BookingService', () => {
 
       const results = await service.listOfBookingsForPremisesId(premisesId)
 
-      expect(results).toEqual(service.bookingsToTableRows(bookings, premisesId))
+      expect(results).toEqual(service.bookingsToTableRows(bookings, premisesId, 'arrival'))
 
       expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
     })
@@ -110,10 +132,14 @@ describe('BookingService', () => {
 
       const results = await service.groupedListOfBookingsForPremisesId('some-uuid')
 
-      expect(results.arrivingToday).toEqual(service.bookingsToTableRows(bookingsArrivingToday, premisesId))
-      expect(results.departingToday).toEqual(service.bookingsToTableRows(bookingsDepartingToday, premisesId))
-      expect(results.upcomingArrivals).toEqual(service.bookingsToTableRows(bookingsArrivingSoon, premisesId))
-      expect(results.upcomingDepartures).toEqual(service.bookingsToTableRows(bookingsDepartingSoon, premisesId))
+      expect(results.arrivingToday).toEqual(service.bookingsToTableRows(bookingsArrivingToday, premisesId, 'arrival'))
+      expect(results.departingToday).toEqual(
+        service.bookingsToTableRows(bookingsDepartingToday, premisesId, 'departure'),
+      )
+      expect(results.upcomingArrivals).toEqual(service.bookingsToTableRows(bookingsArrivingSoon, premisesId, 'arrival'))
+      expect(results.upcomingDepartures).toEqual(
+        service.bookingsToTableRows(bookingsDepartingSoon, premisesId, 'departure'),
+      )
 
       expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
     })

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -31,7 +31,7 @@ describe('BookingService', () => {
 
   describe('getBooking', () => {
     it('on success returns the booking that has been requested', async () => {
-      const booking = BookingFactory.build({
+      const booking = bookingFactory.build({
         arrivalDate: new Date(2022, 2, 11).toISOString(),
         expectedDepartureDate: new Date(2022, 2, 12).toISOString(),
       })
@@ -43,18 +43,15 @@ describe('BookingService', () => {
     })
   })
 
-  describe('listOfBookingsForPremisesId', () => {
-    it('should return table rows of bookings', async () => {
+  describe('bookingsToTableRows', () => {
+    it('should convert bookings to table rows', () => {
+      const premisesId = 'some-uuid'
       const bookings = [
         bookingFactory.build({ arrivalDate: new Date(2022, 10, 22).toISOString() }),
         bookingFactory.build({ arrivalDate: new Date(2022, 2, 11).toISOString() }),
       ]
-      const premisesId = 'some-uuid'
-      bookingClient.allBookingsForPremisesId.mockResolvedValue(bookings)
 
-      const results = await service.listOfBookingsForPremisesId('some-uuid')
-
-      expect(results.length).toEqual(2)
+      const results = service.bookingsToTableRows(bookings, premisesId)
 
       expect(results[0][0]).toEqual({ text: bookings[0].CRN })
       expect(results[0][1]).toEqual({ text: '22/11/2022' })
@@ -67,6 +64,56 @@ describe('BookingService', () => {
       expect(results[1][2]).toEqual({
         html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[1].id}/arrivals/new`),
       })
+    })
+  })
+
+  describe('listOfBookingsForPremisesId', () => {
+    it('should return table rows of bookings', async () => {
+      const premisesId = 'some-uuid'
+      const bookings = bookingFactory.buildList(3)
+
+      bookingClient.allBookingsForPremisesId.mockResolvedValue(bookings)
+
+      const results = await service.listOfBookingsForPremisesId(premisesId)
+
+      expect(results).toEqual(service.bookingsToTableRows(bookings, premisesId))
+
+      expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
+    })
+  })
+
+  describe('groupedListOfBookingsForPremisesId', () => {
+    it('should return table rows of bookings', async () => {
+      const bookingsArrivingToday = bookingFactory.arrivingToday().buildList(2)
+      const arrivedBookings = bookingFactory.arrivedToday().buildList(2)
+
+      const bookingsDepartingToday = bookingFactory.departingToday().buildList(3)
+      const departedBookings = bookingFactory.departedToday().buildList(5)
+
+      const bookingsArrivingSoon = bookingFactory.arrivingSoon().buildList(2)
+
+      const cancelledBookingsWithFutureArrivalDate = bookingFactory.cancelledWithFutureArrivalDate().buildList(2)
+
+      const bookingsDepartingSoon = bookingFactory.departingSoon().buildList(3)
+
+      const bookings = [
+        ...bookingsArrivingToday,
+        ...arrivedBookings,
+        ...bookingsDepartingToday,
+        ...departedBookings,
+        ...bookingsArrivingSoon,
+        ...cancelledBookingsWithFutureArrivalDate,
+        ...bookingsDepartingSoon,
+      ]
+      const premisesId = 'some-uuid'
+      bookingClient.allBookingsForPremisesId.mockResolvedValue(bookings)
+
+      const results = await service.groupedListOfBookingsForPremisesId('some-uuid')
+
+      expect(results.arrivingToday).toEqual(service.bookingsToTableRows(bookingsArrivingToday, premisesId))
+      expect(results.departingToday).toEqual(service.bookingsToTableRows(bookingsDepartingToday, premisesId))
+      expect(results.upcomingArrivals).toEqual(service.bookingsToTableRows(bookingsArrivingSoon, premisesId))
+      expect(results.upcomingDepartures).toEqual(service.bookingsToTableRows(bookingsDepartingSoon, premisesId))
 
       expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
     })

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -1,11 +1,14 @@
-import parseISO from 'date-fns/parseISO'
+import { parseISO, isSameDay, isWithinInterval, addDays } from 'date-fns'
 
-import type { Booking, BookingDto, TableRow } from 'approved-premises'
+import type { Booking, BookingDto, TableRow, GroupedListofBookings } from 'approved-premises'
+
 import type { RestClientBuilder } from '../data'
 import BookingClient from '../data/bookingClient'
 import { convertDateString } from '../utils/utils'
 
 export default class BookingService {
+  UPCOMING_WINDOW_IN_DAYS = 5
+
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
   async postBooking(premisesId: string, booking: BookingDto): Promise<Booking> {
@@ -40,6 +43,25 @@ export default class BookingService {
 
     const bookings = await bookingClient.allBookingsForPremisesId(premisesId)
 
+    return this.bookingsToTableRows(bookings, premisesId)
+  }
+
+  async groupedListOfBookingsForPremisesId(premisesId: string): Promise<GroupedListofBookings> {
+    const token = 'FAKE_TOKEN'
+    const bookingClient = this.bookingClientFactory(token)
+
+    const bookings = await bookingClient.allBookingsForPremisesId(premisesId)
+    const today = new Date(new Date().setHours(0, 0, 0, 0))
+
+    return {
+      arrivingToday: this.bookingsToTableRows(this.bookingsArrivingToday(bookings, today), premisesId),
+      departingToday: this.bookingsToTableRows(this.bookingsDepartingToday(bookings, today), premisesId),
+      upcomingArrivals: this.bookingsToTableRows(this.upcomingArrivals(bookings, today), premisesId),
+      upcomingDepartures: this.bookingsToTableRows(this.upcomingDepartures(bookings, today), premisesId),
+    }
+  }
+
+  bookingsToTableRows(bookings: Array<Booking>, premisesId: string): Array<TableRow> {
     return bookings.map(booking => [
       {
         text: booking.CRN,
@@ -56,5 +78,40 @@ export default class BookingService {
         </a>`,
       },
     ])
+  }
+
+  private bookingsArrivingToday(bookings: Array<Booking>, today: Date): Array<Booking> {
+    return this.bookingsAwaitingArrival(bookings).filter(booking =>
+      isSameDay(convertDateString(booking.arrivalDate), today),
+    )
+  }
+
+  private bookingsDepartingToday(bookings: Array<Booking>, today: Date): Array<Booking> {
+    return this.arrivedBookings(bookings).filter(booking =>
+      isSameDay(convertDateString(booking.expectedDepartureDate), today),
+    )
+  }
+
+  private upcomingArrivals(bookings: Array<Booking>, today: Date): Array<Booking> {
+    return this.bookingsAwaitingArrival(bookings).filter(booking => this.isUpcoming(booking.arrivalDate, today))
+  }
+
+  private upcomingDepartures(bookings: Array<Booking>, today: Date): Array<Booking> {
+    return this.arrivedBookings(bookings).filter(booking => this.isUpcoming(booking.expectedDepartureDate, today))
+  }
+
+  private arrivedBookings(bookings: Array<Booking>): Array<Booking> {
+    return bookings.filter(booking => booking.status === 'arrived')
+  }
+
+  private bookingsAwaitingArrival(bookings: Array<Booking>): Array<Booking> {
+    return bookings.filter(booking => booking.status === 'awaiting-arrival')
+  }
+
+  private isUpcoming(date: string, today: Date) {
+    return isWithinInterval(convertDateString(date), {
+      start: addDays(today, 1),
+      end: addDays(today, this.UPCOMING_WINDOW_IN_DAYS + 1),
+    })
   }
 }

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -43,7 +43,7 @@ export default class BookingService {
 
     const bookings = await bookingClient.allBookingsForPremisesId(premisesId)
 
-    return this.bookingsToTableRows(bookings, premisesId)
+    return this.bookingsToTableRows(bookings, premisesId, 'arrival')
   }
 
   async groupedListOfBookingsForPremisesId(premisesId: string): Promise<GroupedListofBookings> {
@@ -54,20 +54,22 @@ export default class BookingService {
     const today = new Date(new Date().setHours(0, 0, 0, 0))
 
     return {
-      arrivingToday: this.bookingsToTableRows(this.bookingsArrivingToday(bookings, today), premisesId),
-      departingToday: this.bookingsToTableRows(this.bookingsDepartingToday(bookings, today), premisesId),
-      upcomingArrivals: this.bookingsToTableRows(this.upcomingArrivals(bookings, today), premisesId),
-      upcomingDepartures: this.bookingsToTableRows(this.upcomingDepartures(bookings, today), premisesId),
+      arrivingToday: this.bookingsToTableRows(this.bookingsArrivingToday(bookings, today), premisesId, 'arrival'),
+      departingToday: this.bookingsToTableRows(this.bookingsDepartingToday(bookings, today), premisesId, 'departure'),
+      upcomingArrivals: this.bookingsToTableRows(this.upcomingArrivals(bookings, today), premisesId, 'arrival'),
+      upcomingDepartures: this.bookingsToTableRows(this.upcomingDepartures(bookings, today), premisesId, 'departure'),
     }
   }
 
-  bookingsToTableRows(bookings: Array<Booking>, premisesId: string): Array<TableRow> {
+  bookingsToTableRows(bookings: Array<Booking>, premisesId: string, type: 'arrival' | 'departure'): Array<TableRow> {
     return bookings.map(booking => [
       {
         text: booking.CRN,
       },
       {
-        text: convertDateString(booking.arrivalDate).toLocaleDateString('en-GB'),
+        text: convertDateString(
+          type === 'arrival' ? booking.arrivalDate : booking.expectedDepartureDate,
+        ).toLocaleDateString('en-GB'),
       },
       {
         html: `<a href="/premises/${premisesId}/bookings/${booking.id}/arrivals/new">

--- a/server/testutils/factories/booking.ts
+++ b/server/testutils/factories/booking.ts
@@ -1,16 +1,77 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
+import { addDays, startOfToday } from 'date-fns'
 
 import type { Booking } from 'approved-premises'
 import arrivalFactory from './arrival'
 
-export default Factory.define<Booking>(() => ({
+const today = startOfToday().toISOString()
+const soon = () => faker.date.soon(5, addDays(new Date(new Date().setHours(0, 0, 0, 0)), 1)).toISOString()
+const past = () => faker.date.past().toISOString()
+const future = () => faker.date.future().toISOString()
+class BookingFactory extends Factory<Booking> {
+  arrivingToday() {
+    return this.params({
+      arrivalDate: today,
+      status: 'awaiting-arrival',
+    })
+  }
+
+  arrivedToday() {
+    return this.params({
+      arrivalDate: today,
+      status: 'arrived',
+    })
+  }
+
+  departingToday() {
+    return this.params({
+      arrivalDate: past(),
+      expectedDepartureDate: today,
+      status: 'arrived',
+    })
+  }
+
+  departedToday() {
+    return this.params({
+      arrivalDate: past(),
+      expectedDepartureDate: today,
+      status: 'departed',
+    })
+  }
+
+  arrivingSoon() {
+    return this.params({
+      arrivalDate: soon(),
+      expectedDepartureDate: future(),
+      status: 'awaiting-arrival',
+    })
+  }
+
+  cancelledWithFutureArrivalDate() {
+    return this.params({
+      arrivalDate: soon(),
+      expectedDepartureDate: future(),
+      status: 'cancelled',
+    })
+  }
+
+  departingSoon() {
+    return this.params({
+      expectedDepartureDate: soon(),
+      arrivalDate: past(),
+      status: 'arrived',
+    })
+  }
+}
+
+export default BookingFactory.define(() => ({
   CRN: faker.datatype.uuid(),
   arrivalDate: faker.date.soon().toISOString(),
   expectedDepartureDate: faker.date.future().toISOString(),
   keyWorker: `${faker.name.firstName()} ${faker.name.lastName()}`,
   name: `${faker.name.firstName()} ${faker.name.lastName()}`,
   id: faker.datatype.uuid(),
-  status: 'awaiting-arrival',
+  status: 'awaiting-arrival' as const,
   arrival: arrivalFactory.build(),
 }))

--- a/server/testutils/factories/bookingDto.ts
+++ b/server/testutils/factories/bookingDto.ts
@@ -1,16 +1,13 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
-import type { Booking } from 'approved-premises'
-import arrivalFactory from './arrival'
+import type { BookingDto } from 'approved-premises'
 
-export default Factory.define<Booking>(() => ({
+export default Factory.define<BookingDto>(() => ({
   CRN: faker.datatype.uuid(),
+  name: `${faker.name.firstName()} ${faker.name.lastName()}`,
   arrivalDate: faker.date.soon().toISOString(),
   expectedDepartureDate: faker.date.future().toISOString(),
   keyWorker: `${faker.name.firstName()} ${faker.name.lastName()}`,
-  name: `${faker.name.firstName()} ${faker.name.lastName()}`,
   id: faker.datatype.uuid(),
-  status: 'awaiting-arrival',
-  arrival: arrivalFactory.build(),
 }))

--- a/server/views/premises/bookings/_table.njk
+++ b/server/views/premises/bookings/_table.njk
@@ -1,0 +1,25 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% macro bookingTable(title, dateField, rows) %}
+	{% if rows %}
+		{{
+      govukTable({
+        caption: title,
+        captionClasses: "govuk-table__caption--m",
+        firstCellIsHeader: true,
+        head: [
+          {
+            text: "CRN"
+          },
+          {
+            text: "Expected "+ dateField +" Date"
+          },
+          {
+            html: '<span class="govuk-visually-hidden">Actions</span>'
+          }
+        ],
+        rows: rows
+      })
+    }}
+	{% endif %}
+{% endmacro %}

--- a/server/views/premises/show.njk
+++ b/server/views/premises/show.njk
@@ -1,6 +1,8 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
+{% from "./bookings/_table.njk" import bookingTable %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -20,24 +22,39 @@
 		govukSummaryList(premises.summaryList)
 	}}
 
-	{{
-      govukTable({
-				caption: "Current Bookings",
-        captionClasses: "govuk-table__caption--l",
-        firstCellIsHeader: true,
-        head: [
-          {
-            text: "CRN"
-          },
-          {
-            text: "Expected Arrival Date"
-          },
-          {
-            html: '<span class="govuk-visually-hidden">Actions</span>'
-          }
-        ],
-        rows: bookings
-      })
-    }}
+	<h2>Arrivals and Departures</h2>
+
+	{{ govukTabs({
+  items: [
+    {
+      label: "Arriving Today",
+      id: "arriving-today",
+      panel: {
+        html: bookingTable("Arriving Today", "Arrival", bookings.arrivingToday)
+      }
+    },
+    {
+      label: "Departing Today",
+      id: "departing-today",
+      panel: {
+        html: bookingTable("Departing Today", "Departure", bookings.departingToday)
+      }
+    },
+    {
+      label: "Upcoming Arrivals",
+      id: "upcoming-arrivals",
+      panel: {
+        html: bookingTable("Upcoming Arrivals", "Arrival", bookings.upcomingArrivals)
+      }
+    },
+    {
+      label: "Upcoming Departures",
+      id: "upcoming-departures",
+      panel: {
+        html: bookingTable("Upcoming Departures", "Departute", bookings.upcomingDepartures)
+      }
+    }
+  ]
+}) }}
 
 {% endblock %}

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -2,6 +2,7 @@
 import { stubFor } from './index'
 
 import premises from './stubs/premises.json'
+import bookingDtoFactory from '../server/testutils/factories/bookingDto'
 import bookingFactory from '../server/testutils/factories/booking'
 import arrivalFactory from '../server/testutils/factories/arrival'
 
@@ -70,7 +71,7 @@ stubs.push(async () =>
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      body: JSON.stringify(bookingFactory.build()),
+      body: JSON.stringify(bookingDtoFactory.build()),
     },
   }),
 )

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -41,7 +41,17 @@ premises.forEach(p => {
     }),
   )
 
-  const bookings = bookingFactory.buildList(Math.floor(Math.random() * 10))
+  const rand = () => Math.floor(Math.random() * 10)
+
+  const bookings = [
+    bookingFactory.arrivingToday().buildList(rand()),
+    bookingFactory.arrivedToday().buildList(rand()),
+    bookingFactory.departingToday().buildList(rand()),
+    bookingFactory.departedToday().buildList(rand()),
+    bookingFactory.arrivingSoon().buildList(rand()),
+    bookingFactory.cancelledWithFutureArrivalDate().buildList(rand()),
+    bookingFactory.departingSoon().buildList(rand()),
+  ].flat()
 
   stubs.push(async () =>
     stubFor({


### PR DESCRIPTION
This groups bookings into types in a tabbed view. To get this to work properly, we needed to add a `status` field to the API, which has been documented in Swagger. I've also added some traits to the booking factory, which makes it easier to create types of bookings in test and for stubs.

# Screenshot

![image](https://user-images.githubusercontent.com/109774/181478151-0d54d1e1-2009-44f4-9615-434a080b2040.png)
