### PR TITLE
(500) Create a non arrival

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,6 +5,7 @@ import tokenVerification from './integration_tests/mockApis/tokenVerification'
 import premises from './integration_tests/mockApis/premises'
 import booking from './integration_tests/mockApis/booking'
 import arrival from './integration_tests/mockApis/arrival'
+import nonArrival from './integration_tests/mockApis/nonArrival'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -24,6 +25,7 @@ export default defineConfig({
       on('task', {
         reset: resetStubs,
         ...arrival,
+        ...nonArrival,
         ...auth,
         ...tokenVerification,
         ...premises,

--- a/integration_tests/e2e/arrivals.cy.ts
+++ b/integration_tests/e2e/arrivals.cy.ts
@@ -1,5 +1,6 @@
 import premisesFactory from '../../server/testutils/factories/premises'
 import arrivalFactory from '../../server/testutils/factories/arrival'
+import nonArrivalFactory from '../../server/testutils/factories/nonArrival'
 
 import ArrivalCreatePage from '../pages/arrivalCreate'
 import PremisesShowPage from '../pages/premisesShow'
@@ -28,7 +29,7 @@ context('Arrivals', () => {
 
     // When I mark the booking as having arrived
     const page = ArrivalCreatePage.visit(premises.id, bookingId)
-    page.completeForm(arrival)
+    page.completeArrivalForm(arrival)
 
     // Then an arrival should be created in the API
     cy.task('verifyArrivalCreate', { premisesId: premises.id, bookingId }).then(requests => {
@@ -40,6 +41,39 @@ context('Arrivals', () => {
       expect(requestBody.notes).equal(arrival.notes)
       expect(requestBody.dateTime).equal(dateTime)
       expect(requestBody.expectedDeparture).equal(expectedDeparture)
+    })
+
+    // And I should be redirected to the premises page
+    PremisesShowPage.verifyOnPage(PremisesShowPage, premises)
+  })
+
+  it('creates a non-arrival', () => {
+    // Given I am logged in
+    cy.signIn()
+
+    // And I have a booking for a premises
+    const premises = premisesFactory.build()
+    const bookingId = 'some-uuid'
+    const nonArrival = nonArrivalFactory.build({
+      date: new Date(2022, 1, 11).toISOString(),
+      reason: 'recalled',
+    })
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubNonArrivalCreate', { premisesId: premises.id, bookingId, nonArrival })
+
+    // When I mark the booking as having not arrived
+    const page = ArrivalCreatePage.visit(premises.id, bookingId)
+    page.completeNonArrivalForm(nonArrival)
+
+    // Then a non-arrival should be created in the API
+    cy.task('verifyNonArrivalCreate', { premisesId: premises.id, bookingId }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+
+      expect(requestBody.notes).equal(nonArrival.notes)
+      expect(requestBody.date).equal(nonArrival.date)
+      expect(requestBody.reason).equal(nonArrival.reason)
     })
 
     // And I should be redirected to the premises page

--- a/integration_tests/e2e/arrivals.cy.ts
+++ b/integration_tests/e2e/arrivals.cy.ts
@@ -20,8 +20,8 @@ context('Arrivals', () => {
     const premises = premisesFactory.build()
     const bookingId = 'some-uuid'
     const arrival = arrivalFactory.build({
-      dateTime: new Date(2022, 1, 11).toISOString(),
-      expectedDeparture: new Date(2022, 11, 11).toISOString(),
+      date: new Date(2022, 1, 11).toISOString(),
+      expectedDepartureDate: new Date(2022, 11, 11).toISOString(),
     })
 
     cy.task('stubSinglePremises', premises)
@@ -36,11 +36,11 @@ context('Arrivals', () => {
       expect(requests).to.have.length(1)
       const requestBody = JSON.parse(requests[0].body)
 
-      const { dateTime, expectedDeparture } = arrival
+      const { date, expectedDepartureDate } = arrival
 
       expect(requestBody.notes).equal(arrival.notes)
-      expect(requestBody.dateTime).equal(dateTime)
-      expect(requestBody.expectedDeparture).equal(expectedDeparture)
+      expect(requestBody.date).equal(date)
+      expect(requestBody.expectedDepartureDate).equal(expectedDepartureDate)
     })
 
     // And I should be redirected to the premises page

--- a/integration_tests/mockApis/nonArrival.ts
+++ b/integration_tests/mockApis/nonArrival.ts
@@ -1,0 +1,27 @@
+import { SuperAgentRequest } from 'superagent'
+
+import type { NonArrival } from 'approved-premises'
+
+import { stubFor, getMatchingRequests } from '../../wiremock'
+
+export default {
+  stubNonArrivalCreate: (args: { premisesId: string; bookingId: string; nonArrival: NonArrival }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: `/premises/${args.premisesId}/bookings/${args.bookingId}/non-arrivals`,
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.nonArrival,
+      },
+    }),
+  verifyNonArrivalCreate: async (args: { premisesId: string; bookingId: string }) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: `/premises/${args.premisesId}/bookings/${args.bookingId}/non-arrivals`,
+      })
+    ).body.requests,
+}

--- a/integration_tests/pages/arrivalCreate.ts
+++ b/integration_tests/pages/arrivalCreate.ts
@@ -17,20 +17,20 @@ export default class ArrivalCreatePage extends Page {
 
     cy.log('arrival', arrival)
 
-    const dateTime = new Date(Date.parse(arrival.dateTime))
-    const expectedDeparture = new Date(Date.parse(arrival.expectedDeparture))
+    const date = new Date(Date.parse(arrival.date))
+    const expectedDeparture = new Date(Date.parse(arrival.expectedDepartureDate))
 
-    cy.get('input[name="dateTime-day"]').type(String(dateTime.getDate()))
-    cy.get('input[name="dateTime-month"]').type(String(dateTime.getMonth() + 1))
-    cy.get('input[name="dateTime-year"]').type(String(dateTime.getFullYear()))
+    cy.get('input[name="date-day"]').type(String(date.getDate()))
+    cy.get('input[name="date-month"]').type(String(date.getMonth() + 1))
+    cy.get('input[name="date-year"]').type(String(date.getFullYear()))
 
-    cy.get('input[name="expectedDeparture-day"]').type(String(expectedDeparture.getDate()))
-    cy.get('input[name="expectedDeparture-month"]').type(String(expectedDeparture.getMonth() + 1))
-    cy.get('input[name="expectedDeparture-year"]').type(String(expectedDeparture.getFullYear()))
+    cy.get('input[name="expectedDepartureDate-day"]').type(String(expectedDeparture.getDate()))
+    cy.get('input[name="expectedDepartureDate-month"]').type(String(expectedDeparture.getMonth() + 1))
+    cy.get('input[name="expectedDepartureDate-year"]').type(String(expectedDeparture.getFullYear()))
 
-    cy.get('#conditional-arrived > form >> textarea[name="notes"]').type(arrival.notes)
+    cy.get('[name="arrival[notes]"]').type(arrival.notes)
 
-    cy.get('#conditional-arrived > form > .govuk-button').click()
+    cy.get('[name="arrival[submit]"]').click()
   }
 
   public completeNonArrivalForm(nonArrival: NonArrival): void {

--- a/integration_tests/pages/arrivalCreate.ts
+++ b/integration_tests/pages/arrivalCreate.ts
@@ -1,4 +1,4 @@
-import type { Arrival } from 'approved-premises'
+import type { Arrival, NonArrival } from 'approved-premises'
 
 import Page from './page'
 
@@ -12,7 +12,7 @@ export default class ArrivalCreatePage extends Page {
     return new ArrivalCreatePage(premisesId, bookingId)
   }
 
-  public completeForm(arrival: Arrival): void {
+  public completeArrivalForm(arrival: Arrival): void {
     cy.get('input[name="arrived"][value="Yes"]').check()
 
     cy.log('arrival', arrival)
@@ -28,8 +28,26 @@ export default class ArrivalCreatePage extends Page {
     cy.get('input[name="expectedDeparture-month"]').type(String(expectedDeparture.getMonth() + 1))
     cy.get('input[name="expectedDeparture-year"]').type(String(expectedDeparture.getFullYear()))
 
-    cy.get('textarea[name="notes"]').type(arrival.notes)
+    cy.get('#conditional-arrived > form >> textarea[name="notes"]').type(arrival.notes)
 
-    cy.get('button').click()
+    cy.get('#conditional-arrived > form > .govuk-button').click()
+  }
+
+  public completeNonArrivalForm(nonArrival: NonArrival): void {
+    cy.get('input[name="arrived"][value="No"]').check()
+
+    cy.log('nonArrival', nonArrival)
+
+    const date = new Date(Date.parse(nonArrival.date))
+
+    cy.get('input[name="nonArrivalDate-day"]').type(String(date.getDate()))
+    cy.get('input[name="nonArrivalDate-month"]').type(String(date.getMonth() + 1))
+    cy.get('input[name="nonArrivalDate-year"]').type(String(date.getFullYear()))
+
+    cy.get('input[type="radio"]').last().check()
+
+    cy.get('[name="nonArrival[notes]"]').type(nonArrival.notes)
+
+    cy.get('[name="nonArrival[submit]"]').click()
   }
 }

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -1,6 +1,7 @@
 declare module 'approved-premises' {
   export type Premises = schemas['Premises']
   export type Arrival = schemas['Arrival']
+  export type NonArrival = schemas['NonArrival']
   export type Booking = schemas['Booking']
 
   export type BookingDto = Omit<Booking, 'id' | 'status' | 'arrival'>
@@ -14,6 +15,10 @@ declare module 'approved-premises' {
     ObjectWithDateParts<'expectedDeparture'>
 
   export type BookingStatus = 'arrived' | 'awaiting-arrival' | 'not-arrived' | 'departed' | 'cancelled'
+
+  export type NonArrivalDto = ObjectWithDateParts<'nonArrivalDate'> & {
+    nonArrival: Omit<NonArrival, 'id' | 'bookingId'>
+  }
 
   export interface HtmlAttributes {
     [key: string]: string
@@ -80,6 +85,12 @@ declare module 'approved-premises' {
       notes: string
       name: string
       CRN: string
+    }
+    NonArrival: {
+      id: string
+      date: string
+      reason: string
+      notes: string
     }
   }
 }

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -10,15 +10,14 @@ declare module 'approved-premises' {
     [P in K]?: string
   }
 
-  export type ArrivalDto = Omit<Arrival, 'id' | 'bookingId'> &
-    ObjectWithDateParts<'dateTime'> &
-    ObjectWithDateParts<'expectedDeparture'>
-
-  export type BookingStatus = 'arrived' | 'awaiting-arrival' | 'not-arrived' | 'departed' | 'cancelled'
+  export type ArrivalDto = ObjectWithDateParts<'date'> &
+    ObjectWithDateParts<'expectedDepartureDate'> & { arrival: Omit<Arrival, 'id' | 'bookingId'> }
 
   export type NonArrivalDto = ObjectWithDateParts<'nonArrivalDate'> & {
     nonArrival: Omit<NonArrival, 'id' | 'bookingId'>
   }
+
+  export type BookingStatus = 'arrived' | 'awaiting-arrival' | 'not-arrived' | 'departed' | 'cancelled'
 
   export interface HtmlAttributes {
     [key: string]: string
@@ -80,8 +79,8 @@ declare module 'approved-premises' {
     Arrival: {
       id: string
       bookingId: string
-      dateTime: string
-      expectedDeparture: string
+      date: string
+      expectedDepartureDate: string
       notes: string
       name: string
       CRN: string

--- a/server/controllers/arrivalsController.test.ts
+++ b/server/controllers/arrivalsController.test.ts
@@ -42,21 +42,21 @@ describe('ArrivalsController', () => {
       }
 
       request.body = {
-        'dateTime-year': 2022,
-        'dateTime-month': 12,
-        'dateTime-day': 11,
-        'expectedDeparture-year': 2022,
-        'expectedDeparture-month': 11,
-        'expectedDeparture-day': 12,
+        'date-year': 2022,
+        'date-month': 12,
+        'date-day': 11,
+        'expectedDepartureDate-year': 2022,
+        'expectedDepartureDate-month': 11,
+        'expectedDepartureDate-day': 12,
         notes: 'Some notes',
       }
 
       requestHandler(request, response, next)
 
       const expectedArrival = {
-        ...request.body,
-        dateTime: new Date(2022, 11, 11).toISOString(),
-        expectedDeparture: new Date(2022, 10, 12).toISOString(),
+        ...request.body.arrival,
+        date: new Date(2022, 11, 11).toISOString(),
+        expectedDepartureDate: new Date(2022, 10, 12).toISOString(),
       }
 
       expect(arrivalService.createArrival).toHaveBeenCalledWith(

--- a/server/controllers/arrivalsController.ts
+++ b/server/controllers/arrivalsController.ts
@@ -20,10 +20,13 @@ export default class ArrivalsController {
       const { premisesId, bookingId } = req.params
       const body = req.body as ArrivalDto
 
+      const { date } = convertDateInputsToIsoString(body, 'date')
+      const { expectedDepartureDate } = convertDateInputsToIsoString(body, 'expectedDepartureDate')
+
       const arrival: Omit<Arrival, 'id' | 'bookingId'> = {
-        ...body,
-        ...convertDateInputsToIsoString(body, 'dateTime'),
-        ...convertDateInputsToIsoString(body, 'expectedDeparture'),
+        ...body.arrival,
+        date,
+        expectedDepartureDate,
       }
 
       this.arrivalService.createArrival(premisesId, bookingId, arrival)

--- a/server/controllers/nonArrivalsController.test.ts
+++ b/server/controllers/nonArrivalsController.test.ts
@@ -1,0 +1,52 @@
+import { Request, Response, NextFunction } from 'express'
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import NonArrivalService from '../services/nonArrivalService'
+
+import NonArrivalsController from './nonArrivalsController'
+
+describe('NonArrivalsController', () => {
+  const request: DeepMocked<Request> = createMock<Request>({})
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  let nonArrivalsController: NonArrivalsController
+  let nonArrivalService: DeepMocked<NonArrivalService>
+
+  beforeEach(() => {
+    nonArrivalService = createMock<NonArrivalService>({})
+    nonArrivalsController = new NonArrivalsController(nonArrivalService)
+  })
+
+  describe('create', () => {
+    it('creates an nonArrival and redirects to the premises page', () => {
+      const requestHandler = nonArrivalsController.create()
+
+      request.params = {
+        bookingId: 'bookingId',
+        premisesId: 'premisesId',
+      }
+
+      request.body = {
+        'nonArrivalDate-year': 2022,
+        'nonArrivalDate-month': 12,
+        'nonArrivalDate-day': 11,
+        nonArrival: { notes: 'Some notes', reason: 'Some reason' },
+      }
+
+      requestHandler(request, response, next)
+
+      const expectedNonArrival = {
+        ...request.body.nonArrival,
+        date: new Date(2022, 11, 11).toISOString(),
+      }
+
+      expect(nonArrivalService.createNonArrival).toHaveBeenCalledWith(
+        request.params.premisesId,
+        request.params.bookingId,
+        expectedNonArrival,
+      )
+
+      expect(response.redirect).toHaveBeenCalledWith(`/premises/${request.params.premisesId}`)
+    })
+  })
+})

--- a/server/controllers/nonArrivalsController.ts
+++ b/server/controllers/nonArrivalsController.ts
@@ -1,0 +1,25 @@
+import { Response, Request, RequestHandler } from 'express'
+import type { NonArrival, NonArrivalDto } from 'approved-premises'
+import { convertDateInputsToIsoString } from '../utils/utils'
+import NonArrivalService from '../services/nonArrivalService'
+
+export default class NonArrivalsController {
+  constructor(private readonly nonArrivalService: NonArrivalService) {}
+
+  create(): RequestHandler {
+    return (req: Request, res: Response) => {
+      const { premisesId, bookingId } = req.params
+      const body = req.body as NonArrivalDto
+      const { nonArrivalDate } = convertDateInputsToIsoString(body, 'nonArrivalDate')
+
+      const nonArrival: Omit<NonArrival, 'id' | 'bookingId'> = {
+        ...body.nonArrival,
+        date: nonArrivalDate,
+      }
+
+      this.nonArrivalService.createNonArrival(premisesId, bookingId, nonArrival)
+
+      res.redirect(`/premises/${premisesId}`)
+    }
+  }
+}

--- a/server/data/arrivalClient.test.ts
+++ b/server/data/arrivalClient.test.ts
@@ -29,8 +29,8 @@ describe('PremisesClient', () => {
     it('should create an arrival', async () => {
       const arrival = arrivalFactory.build()
       const payload = {
-        dateTime: arrival.dateTime.toString(),
-        expectedDeparture: arrival.expectedDeparture.toString(),
+        date: arrival.date.toString(),
+        expectedDepartureDate: arrival.expectedDepartureDate.toString(),
         notes: arrival.notes,
         name: arrival.name,
         CRN: arrival.CRN,
@@ -45,8 +45,8 @@ describe('PremisesClient', () => {
 
       expect(result).toEqual({
         ...arrival,
-        dateTime: arrival.dateTime,
-        expectedDeparture: arrival.expectedDeparture,
+        date: arrival.date,
+        expectedDepartureDate: arrival.expectedDepartureDate,
       })
       expect(nock.isDone()).toBeTruthy()
     })

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -14,6 +14,7 @@ buildAppInsightsClient()
 import HmppsAuthClient from './hmppsAuthClient'
 import PremisesClient from './premisesClient'
 import ArrivalClient from './arrivalClient'
+import NonArrivalClient from './nonArrivalClient'
 import { createRedisClient } from './redisClient'
 import TokenStore from './tokenStore'
 
@@ -24,8 +25,9 @@ export const dataAccess = () => ({
   approvedPremisesClientBuilder: ((token: string) => new PremisesClient(token)) as RestClientBuilder<PremisesClient>,
   bookingClientBuilder: ((token: string) => new BookingClient(token)) as RestClientBuilder<BookingClient>,
   arrivalClientBuilder: ((token: string) => new ArrivalClient(token)) as RestClientBuilder<ArrivalClient>,
+  nonArrivalClientBuilder: ((token: string) => new NonArrivalClient(token)) as RestClientBuilder<NonArrivalClient>,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>
 
-export { BookingClient, PremisesClient, ArrivalClient, HmppsAuthClient, RestClientBuilder }
+export { BookingClient, PremisesClient, ArrivalClient, HmppsAuthClient, RestClientBuilder, NonArrivalClient }

--- a/server/data/nonArrivalClient.test.ts
+++ b/server/data/nonArrivalClient.test.ts
@@ -1,0 +1,48 @@
+import nock from 'nock'
+
+import NonArrivalClient from './nonArrivalClient'
+import config from '../config'
+import nonArrivalFactory from '../testutils/factories/nonArrival'
+
+describe('NonArrivalClient', () => {
+  let fakeApprovedPremisesApi: nock.Scope
+  let nonArrivalClient: NonArrivalClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    config.apis.approvedPremises.url = 'http://localhost:8080'
+    fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
+    nonArrivalClient = new NonArrivalClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('create', () => {
+    it('should create an non-arrival', async () => {
+      const nonArrival = nonArrivalFactory.build()
+      const payload = {
+        date: nonArrival.date.toString(),
+        notes: nonArrival.notes,
+        reason: nonArrival.reason,
+      }
+
+      fakeApprovedPremisesApi
+        .post(`/premises/premisesId/bookings/bookingId/non-arrivals`, payload)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, nonArrival)
+
+      const result = await nonArrivalClient.create('premisesId', 'bookingId', payload)
+
+      expect(result).toEqual(nonArrival)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+})

--- a/server/data/nonArrivalClient.ts
+++ b/server/data/nonArrivalClient.ts
@@ -1,0 +1,24 @@
+import type { NonArrival } from 'approved-premises'
+import RestClient from './restClient'
+import config, { ApiConfig } from '../config'
+
+export default class NonArrivalClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('nonArrivalClient', config.apis.approvedPremises as ApiConfig, token)
+  }
+
+  async create(
+    premisesId: string,
+    bookingId: string,
+    nonArrival: Omit<NonArrival, 'id' | 'bookingId'>,
+  ): Promise<NonArrival> {
+    const response = await this.restClient.post({
+      path: `/premises/${premisesId}/bookings/${bookingId}/non-arrivals`,
+      data: nonArrival,
+    })
+
+    return response as NonArrival
+  }
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -6,6 +6,7 @@ import type { Services } from '../services'
 import PremisesController from '../controllers/premisesController'
 import BookingsController from '../controllers/bookingsController'
 import ArrivalsController from '../controllers/arrivalsController'
+import NonArrivalsController from '../controllers/nonArrivalsController'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function routes(services: Services): Router {
@@ -15,6 +16,7 @@ export default function routes(services: Services): Router {
   const premisesController = new PremisesController(services.premisesService, services.bookingService)
   const bookingsController = new BookingsController(services.bookingService)
   const arrivalsController = new ArrivalsController(services.arrivalService)
+  const nonArrivalsController = new NonArrivalsController(services.nonArrivalService)
 
   get('/', (req, res, next) => {
     res.render('pages/index')
@@ -29,6 +31,7 @@ export default function routes(services: Services): Router {
 
   get('/premises/:premisesId/bookings/:bookingId/arrivals/new', arrivalsController.new())
   router.post('/premises/:premisesId/bookings/:bookingId/arrivals', arrivalsController.create())
+  router.post('/premises/:premisesId/bookings/:bookingId/nonArrivals', nonArrivalsController.create())
 
   return router
 }

--- a/server/services/arrivalService.test.ts
+++ b/server/services/arrivalService.test.ts
@@ -23,8 +23,8 @@ describe('ArrivalService', () => {
       const arrival: Arrival = ArrivalFactory.build()
       arrivalClient.create.mockResolvedValue(arrival)
 
-      const postedBooking = await service.createArrival('premisesID', 'bookingId', arrival)
-      expect(postedBooking).toEqual(arrival)
+      const postedArrival = await service.createArrival('premisesID', 'bookingId', arrival)
+      expect(postedArrival).toEqual(arrival)
     })
   })
 })

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -6,23 +6,32 @@ import UserService from './userService'
 import PremisesService from './premisesService'
 import BookingService from './bookingService'
 import ArrivalService from './arrivalService'
+import NonArrivalService from './nonArrivalService'
 
 export const services = () => {
-  const { hmppsAuthClient, approvedPremisesClientBuilder, bookingClientBuilder, arrivalClientBuilder } = dataAccess()
+  const {
+    hmppsAuthClient,
+    approvedPremisesClientBuilder,
+    bookingClientBuilder,
+    arrivalClientBuilder,
+    nonArrivalClientBuilder,
+  } = dataAccess()
 
   const userService = new UserService(hmppsAuthClient)
   const premisesService = new PremisesService(approvedPremisesClientBuilder)
   const bookingService = new BookingService(bookingClientBuilder)
   const arrivalService = new ArrivalService(arrivalClientBuilder)
+  const nonArrivalService = new NonArrivalService(nonArrivalClientBuilder)
 
   return {
     userService,
     premisesService,
     bookingService,
     arrivalService,
+    nonArrivalService,
   }
 }
 
 export type Services = ReturnType<typeof services>
 
-export { UserService, PremisesService, ArrivalService }
+export { UserService, PremisesService, ArrivalService, NonArrivalService }

--- a/server/services/nonArrivalService.test.ts
+++ b/server/services/nonArrivalService.test.ts
@@ -1,0 +1,30 @@
+import type { NonArrival } from 'approved-premises'
+
+import NonArrivalService from './nonArrivalService'
+import NonArrivalClient from '../data/nonArrivalClient'
+import NonArrivalFactory from '../testutils/factories/nonArrival'
+
+jest.mock('../data/nonArrivalClient.ts')
+
+describe('NonArrivalService', () => {
+  const nonArrivalClient = new NonArrivalClient(null) as jest.Mocked<NonArrivalClient>
+  let service: NonArrivalService
+
+  const nonArrivalClientFactory = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    nonArrivalClientFactory.mockReturnValue(nonArrivalClient)
+    service = new NonArrivalService(nonArrivalClientFactory)
+  })
+
+  describe('createNonArrival', () => {
+    it('on success returns the arrival that has been posted', async () => {
+      const nonArrival: NonArrival = NonArrivalFactory.build()
+      nonArrivalClient.create.mockResolvedValue(nonArrival)
+
+      const postedNonArrival = await service.createNonArrival('premisesID', 'bookingId', nonArrival)
+      expect(postedNonArrival).toEqual(nonArrival)
+    })
+  })
+})

--- a/server/services/nonArrivalService.ts
+++ b/server/services/nonArrivalService.ts
@@ -1,0 +1,22 @@
+import type { NonArrival } from 'approved-premises'
+import type { RestClientBuilder, NonArrivalClient } from '../data'
+
+export default class NonArrivalService {
+  // TODO: We need to do some more work on authentication to work
+  // out how to get this token, so let's stub for now
+  token = 'FAKE_TOKEN'
+
+  constructor(private readonly nonArrivalClientFactory: RestClientBuilder<NonArrivalClient>) {}
+
+  async createNonArrival(
+    premisesId: string,
+    bookingId: string,
+    arrival: Omit<NonArrival, 'id' | 'bookingId'>,
+  ): Promise<NonArrival> {
+    const nonArrivalClient = this.nonArrivalClientFactory(this.token)
+
+    const confirmedNonArrival = await nonArrivalClient.create(premisesId, bookingId, arrival)
+
+    return confirmedNonArrival
+  }
+}

--- a/server/testutils/factories/arrival.ts
+++ b/server/testutils/factories/arrival.ts
@@ -5,9 +5,9 @@ import type { Arrival } from 'approved-premises'
 
 export default Factory.define<Arrival>(() => ({
   id: faker.datatype.uuid(),
-  dateTime: faker.date.soon().toISOString(),
+  date: faker.date.soon().toISOString(),
   bookingId: faker.datatype.uuid(),
-  expectedDeparture: faker.date.future().toISOString(),
+  expectedDepartureDate: faker.date.future().toISOString(),
   notes: faker.lorem.sentence(),
   name: `${faker.name.firstName()} ${faker.name.lastName()}`,
   CRN: faker.datatype.uuid(),

--- a/server/testutils/factories/nonArrival.ts
+++ b/server/testutils/factories/nonArrival.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { NonArrival } from 'approved-premises'
+
+export default Factory.define<NonArrival>(() => ({
+  id: faker.datatype.uuid(),
+  bookingId: faker.datatype.uuid(),
+  notes: faker.lorem.sentence(),
+  reason: faker.lorem.word(),
+  date: faker.date.soon().toISOString(),
+}))

--- a/server/views/arrivals/_arrival_form.njk
+++ b/server/views/arrivals/_arrival_form.njk
@@ -1,8 +1,8 @@
 <form action="/premises/{{premisesId}}/bookings/{{bookingId}}/arrivals" method="post">
-	<input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-	{{ govukDateInput({
-    id: "dateTime",
-    namePrefix: "dateTime",
+  <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+  {{ govukDateInput({
+    id: "arrival[date]",
+    namePrefix: "date",
     fieldset: {
     legend: {
         text: "What is the arrival date?",
@@ -14,9 +14,9 @@
     }
   }) }}
 
-	{{ govukDateInput({
-    id: "expectedDeparture",
-    namePrefix: "expectedDeparture",
+  {{ govukDateInput({
+    id: "arrival[expectedDepartureDate]",
+    namePrefix: "expectedDepartureDate",
     fieldset: {
     legend: {
         text: "What is their expected departure date?",
@@ -28,15 +28,16 @@
     }
   }) }}
 
-	{{ govukTextarea({
-    name: "notes",
+  {{ govukTextarea({
+    name: "arrival[notes]",
     id: "notes",
     label: {
       text: "Any other information"
     }
   }) }}
 
-	{{ govukButton({
+  {{ govukButton({
+    name: 'arrival[submit]',
     text: "Submit"
   }) }}
 </form>

--- a/server/views/arrivals/_non-arrival_form.njk
+++ b/server/views/arrivals/_non-arrival_form.njk
@@ -1,0 +1,49 @@
+<form action="/premises/{{premisesId}}/bookings/{{bookingId}}/nonArrivals" method="post">
+  <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+  {{ govukDateInput({
+    id: "nonArrival[date]",
+    namePrefix: "nonArrivalDate",
+    fieldset: {
+    legend: {
+        text: "What was the expected arrival date?",
+        classes: "govuk-fieldset__legend--m"
+        }
+    },
+    hint: {
+        text: "For example, 27 3 2007"
+    }
+  }) }}
+
+  {{ govukRadios({
+  name: "nonArrival[reason]",
+  fieldset: {
+    legend: {
+      text: "Reason",
+      classes: "govuk-fieldset__legend--m"
+    }
+  },
+  items: [
+    {
+      value: "absconded",
+      text: "Absconded"
+    },
+    {
+      value: "recalled",
+      text: "Recalled"
+    }
+  ]
+  }) }}
+
+  {{ govukTextarea({
+    name: "nonArrival[notes]",
+    id: "nonArrival[notes]",
+    label: {
+      text: "Any other information"
+    }
+  }) }}
+
+  {{ govukButton({
+    name: 'nonArrival[submit]',
+    text: "Submit"
+  }) }}
+</form>

--- a/server/views/arrivals/new.njk
+++ b/server/views/arrivals/new.njk
@@ -10,14 +10,18 @@
 
 {% block content %}
 
-	<div class="govuk-grid-row">
-		<div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-			{% set arrivalHTML %}
-			{% include "./_arrival_form.njk" %}
-			{% endset -%}
+      {% set arrivalHTML %}
+      {% include "./_arrival_form.njk" %}
+      {% endset -%}
 
-			{{ govukRadios({
+      {% set nonArrivalHTML %}
+      {% include "./_non-arrival_form.njk" %}
+      {% endset -%}
+
+      {{ govukRadios({
             name: "arrived",
             fieldset: {
               legend: {
@@ -39,11 +43,14 @@
               },
               {
                 value: "No",
-                text: "No"
+                text: "No",
+                conditional: {
+                  html: nonArrivalHTML
+                }
               }
             ]
           })
         }}
-		</div>
-	</div>
+    </div>
+  </div>
 {% endblock %}

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -5,6 +5,7 @@ import premises from './stubs/premises.json'
 import bookingDtoFactory from '../server/testutils/factories/bookingDto'
 import bookingFactory from '../server/testutils/factories/booking'
 import arrivalFactory from '../server/testutils/factories/arrival'
+import nonArrivalFactory from '../server/testutils/factories/nonArrival'
 
 const stubs = []
 
@@ -115,6 +116,23 @@ stubs.push(async () =>
         'Content-Type': 'application/json;charset=UTF-8',
       },
       jsonBody: JSON.stringify(arrivalFactory.build()),
+    },
+  }),
+)
+
+stubs.push(async () =>
+  stubFor({
+    request: {
+      method: 'POST',
+      urlPathPattern:
+        '/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/non-arrivals',
+    },
+    response: {
+      status: 201,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: JSON.stringify(nonArrivalFactory.build()),
     },
   }),
 )


### PR DESCRIPTION
# Context
People can arrive to their AP bookings but they can also not arrive.
We need to be able to record non-arrivals on a booking.

# Changes in this PR

When a user clicks 'Manage' on a booking on the AP detail view they can select if the person who is booked to arrived or did not. Previously when a user select that a user did not arrive nothing happened. 
This PR adds a mini form where the user can select a reason for the non-arrival and add notes about the non-arrival.
The client, service and controller are very similar to the components for arrivals. The UI is similar but with the fields 'non-arrival date', 'reason' and 'notes'.
[Trello ticket](https://trello.com/c/anTARtGW/500-creating-non-arrival)
## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/44123869/181737306-8a214b69-1454-4bc2-a64e-20b79c9f82ee.png)
