### PR TITLE
Add code coverage checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,17 @@
   },
   "jest": {
     "preset": "ts-jest",
+    "collectCoverage": true,
     "collectCoverageFrom": [
-      "server/**/*.{ts,js,jsx,mjs}"
+      "server/**/*.{ts,js,jsx,mjs}",
+      "!server/middleware/*.ts",
+      "!server/authentication/*.ts"
     ],
+    "coverageThreshold": {
+      "global": {
+        "functions": 100
+      }
+    },
     "testMatch": [
       "<rootDir>/(server|job)/**/?(*.)(cy|test).{ts,js,jsx,mjs}"
     ],

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import express from 'express'
 import flash from 'connect-flash'
 

--- a/server/applicationVersion.ts
+++ b/server/applicationVersion.ts
@@ -1,4 +1,6 @@
 // eslint-disable import/no-unresolved,global-require
+/* istanbul ignore file */
+
 import fs from 'fs'
 
 const packageData = JSON.parse(fs.readFileSync('./package.json').toString())

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import 'dotenv/config'
 
 const production = process.env.NODE_ENV === 'production'

--- a/server/data/healthCheck.ts
+++ b/server/data/healthCheck.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import superagent from 'superagent'
 import Agent, { HttpsAgent } from 'agentkeepalive'
 import logger from '../../logger'

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -3,6 +3,8 @@
  * Do appinsights first as it does some magic instrumentation work, i.e. it affects other 'require's
  * In particular, applicationinsights automatically collects bunyan logs
  */
+/* istanbul ignore file */
+
 import { initialiseAppInsights, buildAppInsightsClient } from '../utils/azureAppInsights'
 import BookingClient from './bookingClient'
 

--- a/server/data/redisClient.ts
+++ b/server/data/redisClient.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import { createClient } from 'redis'
 
 import logger from '../../logger'

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import superagent from 'superagent'
 import Agent, { HttpsAgent } from 'agentkeepalive'
 import { Readable } from 'stream'

--- a/server/data/restClientMetricsMiddleware.ts
+++ b/server/data/restClientMetricsMiddleware.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import { Socket } from 'net'
 import promClient from 'prom-client'
 import { Response, SuperAgentRequest } from 'superagent'

--- a/server/data/tokenStore.ts
+++ b/server/data/tokenStore.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import type { RedisClient } from './redisClient'
 
 import logger from '../../logger'

--- a/server/data/tokenVerification.ts
+++ b/server/data/tokenVerification.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import superagent from 'superagent'
 import type { Request } from 'express'
 import getSanitisedError from '../sanitisedError'

--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import type { Request, Response, NextFunction } from 'express'
 import type { HTTPError } from 'superagent'
 import logger from '../logger'

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import promClient from 'prom-client'
 import { createMetricsApp } from './monitoring/metricsApp'
 import createApp from './app'

--- a/server/monitoring/metricsApp.ts
+++ b/server/monitoring/metricsApp.ts
@@ -1,3 +1,6 @@
+/* istanbul ignore file */
+/* istanbul ignore file */
+
 import express from 'express'
 import promBundle from 'express-prom-bundle'
 

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import express, { Express } from 'express'
 import cookieSession from 'cookie-session'
 import createError from 'http-errors'

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import type { ResponseError } from 'superagent'
 
 interface SanitisedError {

--- a/server/services/healthCheck.ts
+++ b/server/services/healthCheck.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import promClient from 'prom-client'
 import { serviceCheckFactory } from '../data/healthCheck'
 import config from '../config'

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import { dataAccess } from '../data'
 
 import UserService from './userService'

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import { config } from 'dotenv'
 import { setup, defaultClient, TelemetryClient, DistributedTracingModes } from 'applicationinsights'
 import applicationVersion from '../applicationVersion'

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-param-reassign */
+/* istanbul ignore file */
+
 import nunjucks from 'nunjucks'
 import express from 'express'
 import * as pathModule from 'path'

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,9 +1,11 @@
 import { parseISO } from 'date-fns'
 import type { ObjectWithDateParts } from 'approved-premises'
 
+/* istanbul ignore next */
 const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
 
+/* istanbul ignore next */
 const isBlank = (str: string): boolean => !str || /^\s*$/.test(str)
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
     "experimentalDecorators": true,
     "typeRoots": ["./server/@types", "./node_modules/@types"]
   },
-  "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist", "cypress.config.ts"],
+  "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist", "cypress.config.ts", "coverage/**"],
   "include": ["**/*.js", "**/*.ts"]
 }


### PR DESCRIPTION
# Context
It's [dxw policy](https://github.com/dxw/tech-team-rfcs/blob/main/rfc-173-testing-our-work.md) to have 100% test coverage for our code.
Previously this check wasn't automated so we could've merged untested code but this didn't happen.
I have opted to go for 100% coverage of functions as that seemed sensible but [we can set coverage by branches, lines and statements too](https://jestjs.io/docs/configuration#coveragethreshold-object).
I have chosen to ignore some config/setup files as it doesn't make sense to test them. The overwhelming majority of these files come from [the template](https://github.com/ministryofjustice/hmpps-template-typescript) and the others are files that connect things together.
Most of these can be ignored by ignoring the `/middleware/` and `/authentication/` folders but I have had to manually ignore some files too.
