### PR TITLE
(449) Add current resident info to premises

### DIFF
--- a/integration_tests/e2e/premises.cy.ts
+++ b/integration_tests/e2e/premises.cy.ts
@@ -52,5 +52,8 @@ context('Premises', () => {
 
     // And I should see all the bookings for that premises listed
     page.shouldShowBookings(bookingsArrivingToday, bookingsLeavingToday, bookingsArrivingSoon, bookingsDepartingSoon)
+
+    // And I should see all the current residents for that premises listed
+    page.shouldShowCurrentResidents(bookingsDepartingSoon)
   })
 })

--- a/integration_tests/pages/premisesShow.ts
+++ b/integration_tests/pages/premisesShow.ts
@@ -80,4 +80,19 @@ export default class PremisesShowPage extends Page {
         })
     })
   }
+
+  shouldShowCurrentResidents(currentResidents: Array<Booking>) {
+    cy.get('h2').should('contain', 'Current Residents')
+    currentResidents.forEach((item: Booking) => {
+      cy.contains(item.CRN)
+        .parent()
+        .within(() => {
+          cy.get('td').eq(0).contains(parseISO(item.expectedDepartureDate).toLocaleDateString('en-GB'))
+          cy.get('td')
+            .eq(1)
+            .contains('Manage')
+            .should('have.attr', 'href', `/premises/${this.premises.id}/bookings/${item.id}/arrivals/new`)
+        })
+    })
+  }
 }

--- a/server/controllers/premisesController.test.ts
+++ b/server/controllers/premisesController.test.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
-import type { SummaryListItem, GroupedListofBookings } from 'approved-premises'
+import type { SummaryListItem, GroupedListofBookings, TableRow } from 'approved-premises'
 import PremisesService from '../services/premisesService'
 import BookingService from '../services/bookingService'
 import PremisesController from './premisesController'
@@ -36,18 +36,21 @@ describe('PremisesController', () => {
     it('should return the premises detail to the template', async () => {
       const premises = { name: 'Some premises', summaryList: { rows: [] as Array<SummaryListItem> } }
       const bookings = createMock<GroupedListofBookings>()
+      const currentResidents = createMock<Array<TableRow>>()
       premisesService.getPremisesDetails.mockResolvedValue(premises)
       bookingService.groupedListOfBookingsForPremisesId.mockResolvedValue(bookings)
+      bookingService.currentResidents.mockResolvedValue(currentResidents)
 
       request.params.id = 'some-uuid'
 
       const requestHandler = premisesController.show()
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('premises/show', { premises, bookings })
+      expect(response.render).toHaveBeenCalledWith('premises/show', { premises, bookings, currentResidents })
 
       expect(premisesService.getPremisesDetails).toHaveBeenCalledWith('some-uuid')
       expect(bookingService.groupedListOfBookingsForPremisesId).toHaveBeenCalledWith('some-uuid')
+      expect(bookingService.currentResidents).toHaveBeenCalledWith('some-uuid')
     })
   })
 })

--- a/server/controllers/premisesController.ts
+++ b/server/controllers/premisesController.ts
@@ -17,7 +17,8 @@ export default class PremisesController {
     return async (req: ShowRequest, res: Response) => {
       const premises = await this.premisesService.getPremisesDetails(req.params.id)
       const bookings = await this.bookingService.groupedListOfBookingsForPremisesId(req.params.id)
-      return res.render('premises/show', { premises, bookings })
+      const currentResidents = await this.bookingService.currentResidents(req.params.id)
+      return res.render('premises/show', { premises, bookings, currentResidents })
     }
   }
 }

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -144,4 +144,19 @@ describe('BookingService', () => {
       expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
     })
   })
+  describe('currentResidents', () => {
+    it('should return table rows of the current residents', async () => {
+      const bookingsArrivingToday = bookingFactory.arrivingToday().buildList(2)
+      const currentResidents = bookingFactory.arrived().buildList(2)
+
+      const premisesId = 'some-uuid'
+      bookingClient.allBookingsForPremisesId.mockResolvedValue([...currentResidents, ...bookingsArrivingToday])
+
+      const results = await service.currentResidents('some-uuid')
+
+      expect(results).toEqual(service.currentResidentsToTableRows(currentResidents, premisesId))
+
+      expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
+    })
+  })
 })

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -66,7 +66,7 @@ describe('BookingService', () => {
       })
     })
 
-    it('should convert bookings to table rows with a departute date', () => {
+    it('should convert bookings to table rows with a departure date', () => {
       const premisesId = 'some-uuid'
       const bookings = [
         bookingFactory.build({ expectedDepartureDate: new Date(2022, 10, 22).toISOString() }),

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -82,6 +82,35 @@ export default class BookingService {
     ])
   }
 
+  async currentResidents(premisesId: string): Promise<Array<TableRow>> {
+    const token = 'FAKE_TOKEN'
+    const bookingClient = this.bookingClientFactory(token)
+
+    const bookings = await bookingClient.allBookingsForPremisesId(premisesId)
+    const arrivedBookings = this.arrivedBookings(bookings)
+
+    return this.currentResidentsToTableRows(arrivedBookings, premisesId)
+  }
+
+  currentResidentsToTableRows(bookings: Array<Booking>, premisesId: string): Array<TableRow> {
+    return bookings.map(booking => [
+      {
+        text: booking.CRN,
+      },
+      {
+        text: convertDateString(booking.expectedDepartureDate).toLocaleDateString('en-GB'),
+      },
+      {
+        html: `<a href="/premises/${premisesId}/bookings/${booking.id}/">
+        Manage
+        <span class="govuk-visually-hidden">
+          booking for ${booking.CRN}
+        </span>
+      </a>`,
+      },
+    ])
+  }
+
   private bookingsArrivingToday(bookings: Array<Booking>, today: Date): Array<Booking> {
     return this.bookingsAwaitingArrival(bookings).filter(booking =>
       isSameDay(convertDateString(booking.arrivalDate), today),

--- a/server/testutils/factories/booking.ts
+++ b/server/testutils/factories/booking.ts
@@ -24,6 +24,14 @@ class BookingFactory extends Factory<Booking> {
     })
   }
 
+  arrived() {
+    return this.params({
+      arrivalDate: past(),
+      expectedDepartureDate: future(),
+      status: 'arrived',
+    })
+  }
+
   departingToday() {
     return this.params({
       arrivalDate: past(),

--- a/server/views/premises/show.njk
+++ b/server/views/premises/show.njk
@@ -51,10 +51,30 @@
       label: "Upcoming Departures",
       id: "upcoming-departures",
       panel: {
-        html: bookingTable("Upcoming Departures", "Departure", bookings.upcomingDepartures)
+        html: bookingTable("Upcoming Departures", "Departute", bookings.upcomingDepartures)
       }
     }
   ]
 }) }}
+
+<h2>Current Residents</h2>
+
+  {{ govukTable({
+    caption: "Current Residents",
+    captionClasses: "govuk-visually-hidden",
+    firstCellIsHeader: true,
+    head: [
+      {
+        text: "Resident"
+      },
+      {
+        text: "Expected Departure Date"
+      },
+      {
+        text: "Actions"
+      }
+    ],
+    rows: currentResidents
+  }) }}
 
 {% endblock %}

--- a/server/views/premises/show.njk
+++ b/server/views/premises/show.njk
@@ -51,7 +51,7 @@
       label: "Upcoming Departures",
       id: "upcoming-departures",
       panel: {
-        html: bookingTable("Upcoming Departures", "Departute", bookings.upcomingDepartures)
+        html: bookingTable("Upcoming Departures", "Departure", bookings.upcomingDepartures)
       }
     }
   ]


### PR DESCRIPTION
# Context
We need to be able to see who is currently resident in an AP in order to perform tasks on that booking - for example soon we will want to mark them as departed.
[Trello ticket](https://trello.com/c/65asE3GA/449-add-current-resident-information-to-premises)

# Changes in this PR
We have added a table of the current residents, their expected departure date and a link to 'Manage' them.
The 'Manage' link does nothing for now but later we will add functionality to mark the resident as departed.

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/44123869/182135910-1ac8b0b4-5b19-435e-b6f8-3177f17001af.png)

### After
![image](https://user-images.githubusercontent.com/44123869/182136853-85f3520a-c026-47f5-8f0c-79a38fbc71e5.png)
