### PR TITLE
(535) Create a departure

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,6 +6,7 @@ import premises from './integration_tests/mockApis/premises'
 import booking from './integration_tests/mockApis/booking'
 import arrival from './integration_tests/mockApis/arrival'
 import nonArrival from './integration_tests/mockApis/nonArrival'
+import departure from './integration_tests/mockApis/departure'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -30,6 +31,7 @@ export default defineConfig({
         ...tokenVerification,
         ...premises,
         ...booking,
+        ...departure,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/integration_tests/e2e/departure.cy.ts
+++ b/integration_tests/e2e/departure.cy.ts
@@ -3,7 +3,7 @@ import departureFactory from '../../server/testutils/factories/departure'
 import bookingFactory from '../../server/testutils/factories/booking'
 
 import DepartureCreatePage from '../pages/departureCreate'
-import PremisesShowPage from '../pages/premisesShow'
+import DepartureConfirmation from '../pages/departureConfirmation'
 
 context('Departures', () => {
   beforeEach(() => {
@@ -30,6 +30,7 @@ context('Departures', () => {
     cy.task('stubPremises', premises)
     cy.task('stubBookingGet', { premisesId: premises[0].id, booking })
     cy.task('stubDepartureCreate', { premisesId: premises[0].id, bookingId: booking.id, departure })
+    cy.task('stubDepartureGet', { premisesId: premises[0].id, bookingId: booking.id, departure })
 
     // When I mark the booking as having departed
     const page = DepartureCreatePage.visit(premises[0].id, booking.id)
@@ -37,7 +38,7 @@ context('Departures', () => {
     page.completeForm(departure)
 
     // Then an departure should be created in the API
-    cy.task('verifyDepartureCreate', { premisesId: premises[0].id, booking: booking.id }).then(requests => {
+    cy.task('verifyDepartureCreate', { premisesId: premises[0].id, bookingId: booking.id }).then(requests => {
       expect(requests).to.have.length(1)
       const requestBody = JSON.parse(requests[0].body)
 
@@ -49,7 +50,9 @@ context('Departures', () => {
       expect(requestBody.notes).equal(departure.notes)
     })
 
-    // And I should be redirected to the premises page
-    PremisesShowPage.verifyOnPage(PremisesShowPage, premises[0])
+    // And I should be redirected to the confirmation page
+    const departureConfirmationPage = DepartureConfirmation.verifyOnPage(DepartureConfirmation, departure, booking)
+
+    departureConfirmationPage.verifyConfirmedDepartureIsVisible(departure, booking)
   })
 })

--- a/integration_tests/e2e/departure.cy.ts
+++ b/integration_tests/e2e/departure.cy.ts
@@ -1,0 +1,55 @@
+import premisesFactory from '../../server/testutils/factories/premises'
+import departureFactory from '../../server/testutils/factories/departure'
+import bookingFactory from '../../server/testutils/factories/booking'
+
+import DepartureCreatePage from '../pages/departureCreate'
+import PremisesShowPage from '../pages/premisesShow'
+
+context('Departures', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+  })
+
+  it('creates an departure', () => {
+    // Given I am logged in
+    cy.signIn()
+
+    // And I have a booking for a premises
+    const premises = premisesFactory.buildList(5)
+    const booking = bookingFactory.build()
+    const departure = departureFactory.build({
+      dateTime: new Date(2022, 1, 11, 12, 35).toISOString(),
+      reason: 'other',
+      destinationAp: premises[2].name,
+      moveOnCategory: 'private-rented',
+      destinationProvider: 'yorkshire-and-the-humber',
+    })
+
+    cy.task('stubPremises', premises)
+    cy.task('stubBookingGet', { premisesId: premises[0].id, booking })
+    cy.task('stubDepartureCreate', { premisesId: premises[0].id, bookingId: booking.id, departure })
+
+    // When I mark the booking as having departed
+    const page = DepartureCreatePage.visit(premises[0].id, booking.id)
+    page.verifySummary(booking)
+    page.completeForm(departure)
+
+    // Then an departure should be created in the API
+    cy.task('verifyDepartureCreate', { premisesId: premises[0].id, booking: booking.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+
+      expect(requestBody.dateTime).equal(departure.dateTime)
+      expect(requestBody.reason).equal(departure.reason)
+      expect(requestBody.destinationAp).equal(departure.destinationAp)
+      expect(requestBody.destinationProvider).equal(departure.destinationProvider)
+      expect(requestBody.moveOnCategory).equal(departure.moveOnCategory)
+      expect(requestBody.notes).equal(departure.notes)
+    })
+
+    // And I should be redirected to the premises page
+    PremisesShowPage.verifyOnPage(PremisesShowPage, premises[0])
+  })
+})

--- a/integration_tests/mockApis/departure.ts
+++ b/integration_tests/mockApis/departure.ts
@@ -5,6 +5,18 @@ import type { Departure } from 'approved-premises'
 import { stubFor, getMatchingRequests } from '../../wiremock'
 
 export default {
+  stubDepartureGet: (args: { premisesId: string; bookingId: string; departure: Departure }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/premises/${args.premisesId}/bookings/${args.bookingId}/departures/${args.departure.id}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.departure,
+      },
+    }),
   stubDepartureCreate: (args: { premisesId: string; bookingId: string; departure: Departure }): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/mockApis/departure.ts
+++ b/integration_tests/mockApis/departure.ts
@@ -1,0 +1,27 @@
+import { SuperAgentRequest } from 'superagent'
+
+import type { Departure } from 'approved-premises'
+
+import { stubFor, getMatchingRequests } from '../../wiremock'
+
+export default {
+  stubDepartureCreate: (args: { premisesId: string; bookingId: string; departure: Departure }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: `/premises/${args.premisesId}/bookings/${args.bookingId}/departures`,
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.departure,
+      },
+    }),
+  verifyDepartureCreate: async (args: { premisesId: string; bookingId: string }) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: `/premises/${args.premisesId}/bookings/${args.bookingId}/departures`,
+      })
+    ).body.requests,
+}

--- a/integration_tests/pages/bookingConfirmation.ts
+++ b/integration_tests/pages/bookingConfirmation.ts
@@ -12,11 +12,6 @@ export default class BookingConfirmationPage extends Page {
     return new BookingConfirmationPage()
   }
 
-  assertDefinition(term: string, value: string): void {
-    cy.get('dt').should('contain', term)
-    cy.get('dd').should('contain', value)
-  }
-
   verifyBookingIsVisible(booking: Booking): void {
     cy.get('dl').within(() => {
       this.assertDefinition('Name', booking.name)

--- a/integration_tests/pages/departureConfirmation.ts
+++ b/integration_tests/pages/departureConfirmation.ts
@@ -1,0 +1,27 @@
+import parseISO from 'date-fns/parseISO'
+import type { Departure, Booking } from 'approved-premises'
+import Page from './page'
+
+export default class DepartureConfirmation extends Page {
+  constructor() {
+    super('Departure confirmed')
+  }
+
+  static visit(premisesId: string, bookingId: string, departureId: string): DepartureConfirmation {
+    cy.visit(`/premises/${premisesId}/bookings/${bookingId}/departures/${departureId}`)
+    return new DepartureConfirmation()
+  }
+
+  verifyConfirmedDepartureIsVisible(departure: Departure, booking: Booking): void {
+    cy.get('dl').within(() => {
+      this.assertDefinition('Name', booking.name)
+      this.assertDefinition('CRN', booking.CRN)
+      this.assertDefinition('Departure date', parseISO(departure.dateTime).toLocaleDateString('en-GB'))
+      this.assertDefinition('Reason', departure.reason)
+      this.assertDefinition('Destination approved premises', departure.destinationAp)
+      this.assertDefinition('Destination provider', departure.destinationProvider)
+      this.assertDefinition('Move on category', departure.moveOnCategory)
+      this.assertDefinition('Notes', departure.notes)
+    })
+  }
+}

--- a/integration_tests/pages/departureCreate.ts
+++ b/integration_tests/pages/departureCreate.ts
@@ -1,0 +1,42 @@
+import type { Departure, Booking } from 'approved-premises'
+
+import Page from './page'
+
+export default class DepartureCreatePage extends Page {
+  constructor(private readonly premisesId: string, private readonly bookingId: string) {
+    super('Log a departure')
+  }
+
+  static visit(premisesId: string, bookingId: string): DepartureCreatePage {
+    cy.visit(`/premises/${premisesId}/bookings/${bookingId}/departures/new`)
+    return new DepartureCreatePage(premisesId, bookingId)
+  }
+
+  public verifySummary(booking: Booking): void {
+    this.assertDefinition('Name', booking.name)
+    this.assertDefinition('CRN', booking.CRN)
+  }
+
+  public completeForm(departure: Departure): void {
+    const dateTime = new Date(Date.parse(departure.dateTime))
+    const minutes = dateTime.getMinutes()
+    const hours = dateTime.getHours()
+
+    cy.get('input[name="dateTime-day"]').type(String(dateTime.getDate()))
+    cy.get('input[name="dateTime-month"]').type(String(dateTime.getMonth() + 1))
+    cy.get('input[name="dateTime-year"]').type(String(dateTime.getFullYear()))
+    cy.get('input[name="dateTime-time"]').type(`${hours}:${minutes}`)
+
+    cy.get('#destinationAp').select(departure.destinationAp)
+
+    cy.get('input[name="departure[reason]"]').last().check()
+
+    cy.get('input[name="departure[moveOnCategory]"]').last().check()
+
+    cy.get('input[name="departure[destinationProvider]"]').last().check()
+
+    cy.get('textarea[name="departure[notes]"]').type(departure.notes)
+
+    cy.get('button').click()
+  }
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -11,6 +11,11 @@ export default abstract class Page {
     this.checkOnPage()
   }
 
+  assertDefinition(term: string, value: string): void {
+    cy.get('dt').should('contain', term)
+    cy.get('dd').should('contain', value)
+  }
+
   checkOnPage(): void {
     cy.get('h1').contains(this.title)
   }

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -2,6 +2,7 @@ declare module 'approved-premises' {
   export type Premises = schemas['Premises']
   export type Arrival = schemas['Arrival']
   export type NonArrival = schemas['NonArrival']
+  export type Departure = schemas['Departure']
   export type Booking = schemas['Booking']
 
   export type BookingDto = Omit<Booking, 'id' | 'status' | 'arrival'>
@@ -16,6 +17,8 @@ declare module 'approved-premises' {
   export type NonArrivalDto = ObjectWithDateParts<'nonArrivalDate'> & {
     nonArrival: Omit<NonArrival, 'id' | 'bookingId'>
   }
+
+  export type DepartureDto = ObjectWithDateParts<'dateTime'> & { departure: Omit<Departure, 'id' | 'bookingId'> }
 
   export type BookingStatus = 'arrived' | 'awaiting-arrival' | 'not-arrived' | 'departed' | 'cancelled'
 
@@ -105,6 +108,16 @@ declare module 'approved-premises' {
       date: string
       reason: string
       notes: string
+    }
+    Departure: {
+      id: string
+      bookingId: string
+      dateTime: string
+      reason: string
+      notes: string
+      moveOnCategory: string
+      destinationProvider: string
+      destinationAp: string
     }
   }
 }

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -8,6 +8,8 @@ declare module 'approved-premises' {
   export type BookingDto = Omit<Booking, 'id' | 'status' | 'arrival'>
 
   export type ObjectWithDateParts<K extends string | number> = { [P in `${K}-${'year' | 'month' | 'day'}`]: string } & {
+    [P in `${K}-time`]?: string
+  } & {
     [P in K]?: string
   }
 

--- a/server/controllers/arrivalsController.ts
+++ b/server/controllers/arrivalsController.ts
@@ -1,7 +1,7 @@
 import type { Response, Request, RequestHandler } from 'express'
 import type { Arrival, ArrivalDto } from 'approved-premises'
 
-import { convertDateInputsToIsoString } from '../utils/utils'
+import { convertDateAndTimeInputsToIsoString } from '../utils/utils'
 import ArrivalService from '../services/arrivalService'
 import renderWithErrors from '../utils/renderWithErrors'
 
@@ -21,8 +21,8 @@ export default class ArrivalsController {
       const { premisesId, bookingId } = req.params
       const body = req.body as ArrivalDto
 
-      const { date } = convertDateInputsToIsoString(body, 'date')
-      const { expectedDepartureDate } = convertDateInputsToIsoString(body, 'expectedDepartureDate')
+      const { date } = convertDateAndTimeInputsToIsoString(body, 'date')
+      const { expectedDepartureDate } = convertDateAndTimeInputsToIsoString(body, 'expectedDepartureDate')
 
       const arrival: Omit<Arrival, 'id' | 'bookingId'> = {
         ...body.arrival,

--- a/server/controllers/bookingsController.ts
+++ b/server/controllers/bookingsController.ts
@@ -2,8 +2,8 @@ import type { BookingDto } from 'approved-premises'
 import type { Request, Response, RequestHandler } from 'express'
 
 import BookingService from '../services/bookingService'
-import { convertDateInputsToIsoString } from '../utils/utils'
 import renderWithErrors from '../utils/renderWithErrors'
+import { convertDateAndTimeInputsToIsoString } from '../utils/utils'
 
 export default class BookingsController {
   constructor(private readonly bookingService: BookingService) {}
@@ -22,8 +22,8 @@ export default class BookingsController {
 
       const booking: BookingDto = {
         ...req.body,
-        ...convertDateInputsToIsoString(req.body, 'arrivalDate'),
-        ...convertDateInputsToIsoString(req.body, 'expectedDepartureDate'),
+        ...convertDateAndTimeInputsToIsoString(req.body, 'arrivalDate'),
+        ...convertDateAndTimeInputsToIsoString(req.body, 'expectedDepartureDate'),
       }
 
       try {

--- a/server/controllers/departuresController.test.ts
+++ b/server/controllers/departuresController.test.ts
@@ -1,0 +1,93 @@
+import type { Request, Response, NextFunction } from 'express'
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import type { Departure } from 'approved-premises'
+
+import DepartureService from '../services/departureService'
+import DeparturesController from './departuresController'
+
+describe('DeparturesController', () => {
+  const request: DeepMocked<Request> = createMock<Request>({})
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  let departuresController: DeparturesController
+  let departureService: DeepMocked<DepartureService>
+
+  beforeEach(() => {
+    departureService = createMock<DepartureService>({})
+    departuresController = new DeparturesController(departureService)
+  })
+
+  describe('new', () => {
+    it('renders the form', async () => {
+      const booking = bookingFactory.build()
+      const bookingId = 'bookingId'
+      const premisesId = 'premisesId'
+      premisesService.getPremisesSelectList.mockResolvedValue([{ value: 'id', text: 'name' }])
+      bookingService.getBooking.mockResolvedValue(booking)
+      const requestHandler = departuresController.new()
+
+      request.params = {
+        bookingId,
+        premisesId,
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(premisesService.getPremisesSelectList).toHaveBeenCalled()
+      expect(bookingService.getBooking).toHaveBeenCalledWith('premisesId', 'bookingId')
+      expect(response.render).toHaveBeenCalledWith('departures/new', {
+        premisesId,
+        booking,
+        premisesSelectList: [
+          {
+            text: 'name',
+            value: 'id',
+          },
+        ],
+      })
+    })
+  })
+
+  describe('create', () => {
+    it('creates an Departure and redirects to the premises page', async () => {
+      const requestHandler = departuresController.create()
+
+      request.params = {
+        bookingId: 'bookingId',
+        premisesId: 'premisesId',
+      }
+
+      request.body = {
+        'dateTime-year': 2022,
+        'dateTime-month': 12,
+        'dateTime-day': 11,
+        'dateTime-time': '12:35',
+        departure: {
+          notes: 'Some notes',
+          reason: 'Bed withdrawn',
+          moveOnCategory: 'Custody',
+          destinationProvider: 'London',
+          destinationAp: 'Some AP',
+          name: 'John Doe',
+          CRN: 'A123456',
+        },
+      }
+
+      await requestHandler(request, response, next)
+
+      const expectedDeparture = {
+        ...request.body.departure,
+        dateTime: new Date(2022, 11, 11, 12, 35).toISOString(),
+      }
+
+      expect(departureService.createDeparture).toHaveBeenCalledWith(
+        request.params.premisesId,
+        request.params.bookingId,
+        expectedDeparture,
+      )
+
+      expect(response.redirect).toHaveBeenCalledWith(`/premises/${request.params.premisesId}`)
+    })
+  })
+})

--- a/server/controllers/departuresController.test.ts
+++ b/server/controllers/departuresController.test.ts
@@ -1,9 +1,9 @@
 import type { Request, Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
-import type { Departure } from 'approved-premises'
 
 import DepartureService from '../services/departureService'
 import DeparturesController from './departuresController'
+import { PremisesService } from '../services'
 
 describe('DeparturesController', () => {
   const request: DeepMocked<Request> = createMock<Request>({})
@@ -12,10 +12,12 @@ describe('DeparturesController', () => {
 
   let departuresController: DeparturesController
   let departureService: DeepMocked<DepartureService>
+  let premisesService: DeepMocked<PremisesService>
 
   beforeEach(() => {
     departureService = createMock<DepartureService>({})
-    departuresController = new DeparturesController(departureService)
+    premisesService = createMock<PremisesService>({})
+    departuresController = new DeparturesController(departureService, premisesService)
   })
 
   describe('new', () => {

--- a/server/controllers/departuresController.ts
+++ b/server/controllers/departuresController.ts
@@ -3,15 +3,16 @@ import type { Departure, DepartureDto } from 'approved-premises'
 
 import { convertDateAndTimeInputsToIsoString } from '../utils/utils'
 import DepartureService from '../services/departureService'
+import PremisesService from '../services/premisesService'
 
 export default class DeparturesController {
-  constructor(private readonly departureService: DepartureService) {}
+  constructor(private readonly departureService: DepartureService, private readonly premisesService: PremisesService) {}
 
   new(): RequestHandler {
-    return (req: Request, res: Response) => {
+    return async (req: Request, res: Response) => {
       const { premisesId, bookingId } = req.params
-
       const booking = await this.bookingService.getBooking(premisesId, bookingId)
+      const premisesSelectList = await this.premisesService.getPremisesSelectList()
 
       res.render('departures/new', { premisesId, booking, premisesSelectList })
     }

--- a/server/controllers/departuresController.ts
+++ b/server/controllers/departuresController.ts
@@ -1,0 +1,36 @@
+import type { Response, Request, RequestHandler } from 'express'
+import type { Departure, DepartureDto } from 'approved-premises'
+
+import { convertDateAndTimeInputsToIsoString } from '../utils/utils'
+import DepartureService from '../services/departureService'
+
+export default class DeparturesController {
+  constructor(private readonly departureService: DepartureService) {}
+
+  new(): RequestHandler {
+    return (req: Request, res: Response) => {
+      const { premisesId, bookingId } = req.params
+
+      const booking = await this.bookingService.getBooking(premisesId, bookingId)
+
+      res.render('departures/new', { premisesId, booking, premisesSelectList })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, bookingId } = req.params
+      const body = req.body as DepartureDto
+      const { dateTime } = convertDateAndTimeInputsToIsoString(body, 'dateTime')
+
+      const departure: Omit<Departure, 'id' | 'bookingId'> = {
+        ...body.departure,
+        dateTime,
+      }
+
+      await this.departureService.createDeparture(premisesId, bookingId, departure)
+
+      res.redirect(`/premises/${premisesId}`)
+    }
+  }
+}

--- a/server/controllers/departuresController.ts
+++ b/server/controllers/departuresController.ts
@@ -4,9 +4,14 @@ import type { Departure, DepartureDto } from 'approved-premises'
 import { convertDateAndTimeInputsToIsoString } from '../utils/utils'
 import DepartureService from '../services/departureService'
 import PremisesService from '../services/premisesService'
+import BookingService from '../services/bookingService'
 
 export default class DeparturesController {
-  constructor(private readonly departureService: DepartureService, private readonly premisesService: PremisesService) {}
+  constructor(
+    private readonly departureService: DepartureService,
+    private readonly premisesService: PremisesService,
+    private readonly bookingService: BookingService,
+  ) {}
 
   new(): RequestHandler {
     return async (req: Request, res: Response) => {
@@ -29,9 +34,24 @@ export default class DeparturesController {
         dateTime,
       }
 
-      await this.departureService.createDeparture(premisesId, bookingId, departure)
+      const { id } = await this.departureService.createDeparture(premisesId, bookingId, departure)
 
-      res.redirect(`/premises/${premisesId}`)
+      return res.redirect(`/premises/${premisesId}/bookings/${bookingId}/departures/${id}/confirmation`)
+    }
+  }
+
+  confirm(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, bookingId, departureId } = req.params
+
+      const booking = await this.bookingService.getBooking(premisesId, bookingId)
+      const departure = await this.departureService.getDeparture(premisesId, bookingId, departureId)
+
+      return res.render(`departures/confirm`, {
+        ...departure,
+        name: booking.name,
+        CRN: booking.CRN,
+      })
     }
   }
 }

--- a/server/controllers/nonArrivalsController.ts
+++ b/server/controllers/nonArrivalsController.ts
@@ -1,6 +1,6 @@
 import { Response, Request, RequestHandler } from 'express'
 import type { NonArrival, NonArrivalDto } from 'approved-premises'
-import { convertDateInputsToIsoString } from '../utils/utils'
+import { convertDateAndTimeInputsToIsoString } from '../utils/utils'
 import NonArrivalService from '../services/nonArrivalService'
 import renderWithErrors from '../utils/renderWithErrors'
 
@@ -11,7 +11,7 @@ export default class NonArrivalsController {
     return async (req: Request, res: Response) => {
       const { premisesId, bookingId } = req.params
       const body = req.body as NonArrivalDto
-      const { nonArrivalDate } = convertDateInputsToIsoString(body, 'nonArrivalDate')
+      const { nonArrivalDate } = convertDateAndTimeInputsToIsoString(body, 'nonArrivalDate')
 
       const nonArrival: Omit<NonArrival, 'id' | 'bookingId'> = {
         ...body.nonArrival,

--- a/server/data/departureClient.test.ts
+++ b/server/data/departureClient.test.ts
@@ -40,4 +40,19 @@ describe('DepartureClient', () => {
       expect(nock.isDone()).toBeTruthy()
     })
   })
+  describe('get', () => {
+    it('given a departure ID should return a departure', async () => {
+      const departure = departureFactory.build()
+
+      fakeApprovedPremisesApi
+        .get(`/premises/premisesId/bookings/bookingId/departures/${departure.id}`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, departure)
+
+      const result = await departureClient.get('premisesId', 'bookingId', departure.id)
+
+      expect(result).toEqual(departure)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
 })

--- a/server/data/departureClient.test.ts
+++ b/server/data/departureClient.test.ts
@@ -1,0 +1,43 @@
+import nock from 'nock'
+
+import DepartureClient from './departureClient'
+import config from '../config'
+import departureFactory from '../testutils/factories/departure'
+
+describe('DepartureClient', () => {
+  let fakeApprovedPremisesApi: nock.Scope
+  let departureClient: DepartureClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    config.apis.approvedPremises.url = 'http://localhost:8080'
+    fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
+    departureClient = new DepartureClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('create', () => {
+    it('should create a departure', async () => {
+      const departure = departureFactory.build()
+
+      fakeApprovedPremisesApi
+        .post(`/premises/premisesId/bookings/bookingId/departures`, departure)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, departure)
+
+      const result = await departureClient.create('premisesId', 'bookingId', departure)
+
+      expect(result).toEqual(departure)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+})

--- a/server/data/departureClient.ts
+++ b/server/data/departureClient.ts
@@ -1,0 +1,24 @@
+import type { Departure } from 'approved-premises'
+import RestClient from './restClient'
+import config, { ApiConfig } from '../config'
+
+export default class DepartureClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('departureClient', config.apis.approvedPremises as ApiConfig, token)
+  }
+
+  async create(
+    premisesId: string,
+    bookingId: string,
+    departure: Omit<Departure, 'id' | 'bookingId'>,
+  ): Promise<Departure> {
+    const response = await this.restClient.post({
+      path: `/premises/${premisesId}/bookings/${bookingId}/departures`,
+      data: departure,
+    })
+
+    return response as Departure
+  }
+}

--- a/server/data/departureClient.ts
+++ b/server/data/departureClient.ts
@@ -21,4 +21,12 @@ export default class DepartureClient {
 
     return response as Departure
   }
+
+  async get(premisesId: string, bookingId: string, departureId: string): Promise<Departure> {
+    const response = await this.restClient.get({
+      path: `/premises/${premisesId}/bookings/${bookingId}/departures/${departureId}`,
+    })
+
+    return response as Departure
+  }
 }

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -15,6 +15,7 @@ import HmppsAuthClient from './hmppsAuthClient'
 import PremisesClient from './premisesClient'
 import ArrivalClient from './arrivalClient'
 import NonArrivalClient from './nonArrivalClient'
+import DepartureClient from './departureClient'
 import { createRedisClient } from './redisClient'
 import TokenStore from './tokenStore'
 
@@ -26,8 +27,17 @@ export const dataAccess = () => ({
   bookingClientBuilder: ((token: string) => new BookingClient(token)) as RestClientBuilder<BookingClient>,
   arrivalClientBuilder: ((token: string) => new ArrivalClient(token)) as RestClientBuilder<ArrivalClient>,
   nonArrivalClientBuilder: ((token: string) => new NonArrivalClient(token)) as RestClientBuilder<NonArrivalClient>,
+  departureClientBuilder: ((token: string) => new DepartureClient(token)) as RestClientBuilder<DepartureClient>,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>
 
-export { BookingClient, PremisesClient, ArrivalClient, HmppsAuthClient, RestClientBuilder, NonArrivalClient }
+export {
+  BookingClient,
+  PremisesClient,
+  ArrivalClient,
+  HmppsAuthClient,
+  RestClientBuilder,
+  NonArrivalClient,
+  DepartureClient,
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -18,7 +18,11 @@ export default function routes(services: Services): Router {
   const bookingsController = new BookingsController(services.bookingService)
   const arrivalsController = new ArrivalsController(services.arrivalService)
   const nonArrivalsController = new NonArrivalsController(services.nonArrivalService)
-  const departuresController = new DeparturesController(services.departureService, services.premisesService)
+  const departuresController = new DeparturesController(
+    services.departureService,
+    services.premisesService,
+    services.bookingService,
+  )
 
   get('/', (req, res, next) => {
     res.render('pages/index')
@@ -36,7 +40,8 @@ export default function routes(services: Services): Router {
   router.post('/premises/:premisesId/bookings/:bookingId/nonArrivals', nonArrivalsController.create())
 
   get('/premises/:premisesId/bookings/:bookingId/departures/new', departuresController.new())
-  router.post('/premises/:premisesId/bookings/:bookingId/departures', departuresController.create())
+  post('/premises/:premisesId/bookings/:bookingId/departures', departuresController.create())
+  get('/premises/:premisesId/bookings/:bookingId/departures/:departureId/confirmation', departuresController.confirm())
 
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,6 +7,7 @@ import PremisesController from '../controllers/premisesController'
 import BookingsController from '../controllers/bookingsController'
 import ArrivalsController from '../controllers/arrivalsController'
 import NonArrivalsController from '../controllers/nonArrivalsController'
+import DeparturesController from '../controllers/departuresController'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function routes(services: Services): Router {
@@ -17,6 +18,7 @@ export default function routes(services: Services): Router {
   const bookingsController = new BookingsController(services.bookingService)
   const arrivalsController = new ArrivalsController(services.arrivalService)
   const nonArrivalsController = new NonArrivalsController(services.nonArrivalService)
+  const departuresController = new DeparturesController(services.departureService, services.premisesService)
 
   get('/', (req, res, next) => {
     res.render('pages/index')
@@ -32,6 +34,9 @@ export default function routes(services: Services): Router {
   get('/premises/:premisesId/bookings/:bookingId/arrivals/new', arrivalsController.new())
   router.post('/premises/:premisesId/bookings/:bookingId/arrivals', arrivalsController.create())
   router.post('/premises/:premisesId/bookings/:bookingId/nonArrivals', nonArrivalsController.create())
+
+  get('/premises/:premisesId/bookings/:bookingId/departures/new', departuresController.new())
+  router.post('/premises/:premisesId/bookings/:bookingId/departures', departuresController.create())
 
   return router
 }

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -101,7 +101,7 @@ export default class BookingService {
         text: convertDateString(booking.expectedDepartureDate).toLocaleDateString('en-GB'),
       },
       {
-        html: `<a href="/premises/${premisesId}/bookings/${booking.id}/">
+        html: `<a href="/premises/${premisesId}/bookings/${booking.id}/departures/new">
         Manage
         <span class="govuk-visually-hidden">
           booking for ${booking.CRN}

--- a/server/services/departureService.test.ts
+++ b/server/services/departureService.test.ts
@@ -1,4 +1,5 @@
 import type { Departure } from 'approved-premises'
+import { parseISO } from 'date-fns'
 
 import DepartureService from './departureService'
 import DepartureClient from '../data/departureClient'
@@ -26,6 +27,20 @@ describe('DepartureService', () => {
       const postedDeparture = await service.createDeparture('premisesId', 'bookingId', departure)
       expect(postedDeparture).toEqual(departure)
       expect(departureClient.create).toHaveBeenCalledWith('premisesId', 'bookingId', departure)
+    })
+  })
+  describe('getDeparture', () => {
+    it('on success returns the departure that has been requested', async () => {
+      const departure: Departure = departureFactory.build()
+      departureClient.get.mockResolvedValue(departure)
+
+      const requestedDeparture = await service.getDeparture('premisesId', 'bookingId', departure.id)
+
+      expect(requestedDeparture).toEqual({
+        ...departure,
+        dateTime: parseISO(departure.dateTime).toLocaleDateString('en-GB'),
+      })
+      expect(departureClient.get).toHaveBeenCalledWith('premisesId', 'bookingId', departure.id)
     })
   })
 })

--- a/server/services/departureService.test.ts
+++ b/server/services/departureService.test.ts
@@ -1,0 +1,31 @@
+import type { Departure } from 'approved-premises'
+
+import DepartureService from './departureService'
+import DepartureClient from '../data/departureClient'
+import departureFactory from '../testutils/factories/departure'
+
+jest.mock('../data/departureClient.ts')
+
+describe('DepartureService', () => {
+  const departureClient = new DepartureClient(null) as jest.Mocked<DepartureClient>
+  let service: DepartureService
+
+  const DepartureClientFactory = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    DepartureClientFactory.mockReturnValue(departureClient)
+    service = new DepartureService(DepartureClientFactory)
+  })
+
+  describe('createDeparture', () => {
+    it('on success returns the departure that has been posted', async () => {
+      const departure: Departure = departureFactory.build()
+      departureClient.create.mockResolvedValue(departure)
+
+      const postedDeparture = await service.createDeparture('premisesId', 'bookingId', departure)
+      expect(postedDeparture).toEqual(departure)
+      expect(departureClient.create).toHaveBeenCalledWith('premisesId', 'bookingId', departure)
+    })
+  })
+})

--- a/server/services/departureService.ts
+++ b/server/services/departureService.ts
@@ -1,3 +1,5 @@
+import { parseISO } from 'date-fns'
+
 import type { Departure } from 'approved-premises'
 import type { RestClientBuilder, DepartureClient } from '../data'
 
@@ -18,5 +20,13 @@ export default class DepartureService {
     const confirmedDeparture = await departureClient.create(premisesId, bookingId, departure)
 
     return confirmedDeparture
+  }
+
+  async getDeparture(premisesId: string, bookingId: string, departureId: string): Promise<Departure> {
+    const departureClient = this.departureClientFactory(this.token)
+
+    const departure = await departureClient.get(premisesId, bookingId, departureId)
+
+    return { ...departure, dateTime: parseISO(departure.dateTime).toLocaleDateString('en-GB') }
   }
 }

--- a/server/services/departureService.ts
+++ b/server/services/departureService.ts
@@ -1,0 +1,22 @@
+import type { Departure } from 'approved-premises'
+import type { RestClientBuilder, DepartureClient } from '../data'
+
+export default class DepartureService {
+  // TODO: We need to do some more work on authentication to work
+  // out how to get this token, so let's stub for now
+  token = 'FAKE_TOKEN'
+
+  constructor(private readonly departureClientFactory: RestClientBuilder<DepartureClient>) {}
+
+  async createDeparture(
+    premisesId: string,
+    bookingId: string,
+    departure: Omit<Departure, 'id' | 'bookingId'>,
+  ): Promise<Departure> {
+    const departureClient = this.departureClientFactory(this.token)
+
+    const confirmedDeparture = await departureClient.create(premisesId, bookingId, departure)
+
+    return confirmedDeparture
+  }
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -7,6 +7,7 @@ import PremisesService from './premisesService'
 import BookingService from './bookingService'
 import ArrivalService from './arrivalService'
 import NonArrivalService from './nonArrivalService'
+import DepartureService from './departureService'
 
 export const services = () => {
   const {
@@ -15,6 +16,7 @@ export const services = () => {
     bookingClientBuilder,
     arrivalClientBuilder,
     nonArrivalClientBuilder,
+    departureClientBuilder,
   } = dataAccess()
 
   const userService = new UserService(hmppsAuthClient)
@@ -22,6 +24,7 @@ export const services = () => {
   const bookingService = new BookingService(bookingClientBuilder)
   const arrivalService = new ArrivalService(arrivalClientBuilder)
   const nonArrivalService = new NonArrivalService(nonArrivalClientBuilder)
+  const departureService = new DepartureService(departureClientBuilder)
 
   return {
     userService,
@@ -29,9 +32,10 @@ export const services = () => {
     bookingService,
     arrivalService,
     nonArrivalService,
+    departureService,
   }
 }
 
 export type Services = ReturnType<typeof services>
 
-export { UserService, PremisesService, ArrivalService, NonArrivalService }
+export { UserService, PremisesService, ArrivalService, NonArrivalService, DepartureService }

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -75,6 +75,24 @@ describe('PremisesService', () => {
     })
   })
 
+  describe('premisesSelectList', () => {
+    it('returns the list mapped into the format required by the nunjucks macro and sorted alphabetically', async () => {
+      const premisesA = premisesFactory.build({ name: 'a' })
+      const premisesB = premisesFactory.build({ name: 'b' })
+      const premisesC = premisesFactory.build({ name: 'c' })
+      premisesClient.getAllPremises.mockResolvedValue([premisesC, premisesB, premisesA, premisesC])
+
+      const result = await service.getPremisesSelectList()
+
+      expect(result).toEqual([
+        { text: 'a', value: 'a' },
+        { text: 'b', value: 'b' },
+        { text: 'c', value: 'c' },
+        { text: 'c', value: 'c' },
+      ])
+    })
+  })
+
   describe('getPremisesDetails', () => {
     it('returns a title and a summary list for a given Premises ID', async () => {
       const premises = premisesFactory.build({ name: 'Test', apCode: 'ABC', postcode: 'SW1A 1AA', bedCount: 50 })

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -34,6 +34,25 @@ export default class PremisesService {
     return { name: premises.name, summaryList }
   }
 
+  async getPremisesSelectList(): Promise<Array<{ text: string; value: string }>> {
+    const premisesClient = this.premisesClientFactory(this.token)
+    const premises = await premisesClient.getAllPremises()
+
+    return premises
+      .map(p => {
+        return { text: `${p.name}`, value: `${p.name}` }
+      })
+      .sort((a, b) => {
+        if (a.text < b.text) {
+          return -1
+        }
+        if (a.text > b.text) {
+          return 1
+        }
+        return 0
+      })
+  }
+
   async summaryListForPremises(premises: Premises): Promise<SummaryList> {
     return {
       rows: [

--- a/server/testutils/factories/departure.ts
+++ b/server/testutils/factories/departure.ts
@@ -1,0 +1,21 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { Departure } from 'approved-premises'
+
+export default Factory.define<Departure>(() => ({
+  id: faker.datatype.uuid(),
+  dateTime: faker.date.soon().toISOString(),
+  bookingId: faker.datatype.uuid(),
+  reason: faker.helpers.arrayElement(['absconded', 'bed-withdrawn', 'recall', 'died', 'other']),
+  notes: faker.lorem.sentence(),
+  moveOnCategory: faker.helpers.arrayElement(['b&b', 'custody', 'no-fixed-abode', 'not-applicable', 'private-rented']),
+  destinationProvider: faker.helpers.arrayElement([
+    'east-of-england',
+    'london',
+    'wales',
+    'greater-manchester',
+    'yorkshire-and-the-humber',
+  ]),
+  destinationAp: faker.address.street(),
+}))

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -2,7 +2,7 @@ import {
   convertDateString,
   convertToTitleCase,
   initialiseName,
-  convertDateInputsToIsoString,
+  convertDateAndTimeInputsToIsoString,
   InvalidDateStringError,
 } from './utils'
 
@@ -49,7 +49,7 @@ describe('convertDateInputsToDateObj', () => {
       'date-day': '11',
     }
 
-    const result = convertDateInputsToIsoString(obj, 'date')
+    const result = convertDateAndTimeInputsToIsoString(obj, 'date')
 
     expect(result.date).toEqual(new Date(2022, 11, 11).toISOString())
   })
@@ -67,9 +67,29 @@ describe('convertDateInputsToDateObj', () => {
       'date-day': '1',
     }
 
-    const result = convertDateInputsToIsoString(obj, 'date')
+    const result = convertDateAndTimeInputsToIsoString(obj, 'date')
 
     expect(result.date).toEqual(new Date(2022, 0, 1).toISOString())
+  })
+
+  it('returns the date with a time if passed one', () => {
+    interface MyObjectWithADate {
+      date?: string
+      ['date-year']: string
+      ['date-month']: string
+      ['date-day']: string
+      ['date-time']: string
+    }
+    const obj: MyObjectWithADate = {
+      'date-year': '2022',
+      'date-month': '1',
+      'date-day': '1',
+      'date-time': '12:35',
+    }
+
+    const result = convertDateAndTimeInputsToIsoString(obj, 'date')
+
+    expect(result.date).toEqual(new Date(2022, 0, 1, 12, 35).toISOString())
   })
 
   it('returns an empty string when given empty strings as input', () => {
@@ -85,7 +105,7 @@ describe('convertDateInputsToDateObj', () => {
       'date-day': '',
     }
 
-    const result = convertDateInputsToIsoString(obj, 'date')
+    const result = convertDateAndTimeInputsToIsoString(obj, 'date')
 
     expect(result.date).toEqual('')
   })
@@ -103,7 +123,7 @@ describe('convertDateInputsToDateObj', () => {
       'date-day': 'foo',
     }
 
-    const result = convertDateInputsToIsoString(obj, 'date')
+    const result = convertDateAndTimeInputsToIsoString(obj, 'date')
 
     expect(result.date.toString()).toEqual('twothousandtwentytwo-20-ooT00:00:00.000Z')
   })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -50,19 +50,22 @@ export const convertDateString = (date: string): Date => {
  * into an ISO8601 date string
  * @param dateInputObj an object with date parts (i.e. `-month` `-day` `-year`), which come from a `govukDateInput`.
  * @param key the key that prefixes each item in the dateInputObj, also the name of the property which the date object will be returned in the return value.
- * @returns name converted to proper case.
+ * @returns an ISO8601 date string.
  */
-export const convertDateInputsToIsoString = <K extends string | number>(
+export const convertDateAndTimeInputsToIsoString = <K extends string | number>(
   dateInputObj: ObjectWithDateParts<K>,
   key: K,
 ) => {
   const day = `0${dateInputObj[`${key}-day`]}`.slice(-2)
   const month = `0${dateInputObj[`${key}-month`]}`.slice(-2)
   const year = dateInputObj[`${key}-year`]
+  const time = dateInputObj[`${key}-time`]
+
+  const timeSegment = time || '00:00'
 
   const o: { [P in K]?: string } = dateInputObj
   if (day && month && year) {
-    o[key] = `${year}-${month}-${day}T00:00:00.000Z`
+    o[key] = `${year}-${month}-${day}T${timeSegment}:00.000Z`
   } else {
     o[key] = ''
   }

--- a/server/views/departures/confirm.njk
+++ b/server/views/departures/confirm.njk
@@ -1,0 +1,93 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Home" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ govukPanel({
+            titleText: "Departure confirmed"
+            }) }}
+            {{ govukSummaryList({
+                rows: [
+                   {
+                    key: {
+                        text: "Name"
+                    },
+                    value: {
+                        text: name
+                    }
+                    },
+                    {
+                    key: {
+                        text: "CRN"
+                    },
+                    value: {
+                        text: CRN
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Departure date"
+                    },
+                    value: {
+                        text: dateTime
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Reason"
+                    },
+                    value: {
+                        text: reason
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Move on category"
+                    },
+                    value: {
+                        text: moveOnCategory
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Destination approved premises"
+                    },
+                    value: {
+                        text: destinationAp
+                    }
+                    },
+                       {
+                    key: {
+                        text: "Destination provider"
+                    },
+                    value: {
+                        text: destinationProvider
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Move on category"
+                    },
+                    value: {
+                        text: moveOnCategory
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Notes"
+                    },
+                    value: {
+                        text: notes
+                    }
+                    }
+                ]
+            }) }}
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/departures/new.njk
+++ b/server/views/departures/new.njk
@@ -1,0 +1,185 @@
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Home" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1>Log a departure</h1>
+            {{ govukSummaryList({
+                rows: [
+                   {
+                    key: {
+                        text: "Name"
+                    },
+                    value: {
+                        text: booking.name
+                    }
+                    },
+                    {
+                    key: {
+                        text: "CRN"
+                    },
+                    value: {
+                        text: booking.CRN
+                    }
+                    }
+                    ]
+            })
+            }}
+            <form action="/premises/{{premisesId}}/bookings/{{booking.id}}/departures" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+                {{ govukDateInput({
+                    id: "dateTime",
+                    namePrefix: "dateTime",
+                    fieldset: {
+                    legend: {
+                        text: "What is the departure date?",
+                        classes: "govuk-fieldset__legend--m"
+                        }
+                    },
+                    hint: {
+                        text: "For example, 27 3 2007"
+                    }
+                }) }}
+
+                <label class="govuk-label govuk-label--m" for="time">
+                    What is the time of departure?
+                </label>
+                <input type="time" id="dateTime-time" name="dateTime-time" class="govuk-input govuk-input--width-5 govuk-!-margin-bottom-4">
+
+                {{ govukSelect({
+                    name: "departure[destinationAp]",
+                    id: "destinationAp",
+                    label: {
+                        text: "Destination Approved Premises",
+                        classes: "govuk-label govuk-label--m"
+                        },
+                    items: premisesSelectList
+                    }) }}
+
+                {{ govukRadios({
+                    name: "departure[reason]",
+                    id: "reason",
+                    fieldset: {
+                        legend: {
+                        text: "Departure reason",
+                        classes: "govuk-fieldset__legend--m"
+                        }
+                    },
+                    items: [
+                        {
+                            text: "Absconded",
+                            value: "absconded"
+                        },
+                        {
+                            text: "Bed withdrawn",
+                            value: "bed-withdrawn"
+                        },
+                        {
+                            text: "Recall",
+                            value: "recall"
+                        },
+                        {
+                            text: "Died",
+                            value: "died"
+                        },
+                        {
+                            text: "Other",
+                            value: "other"
+                        }
+                    ]
+                    }) }}
+
+                {{ govukRadios({
+                    name: "departure[moveOnCategory]",
+                    id: "moveOnCategory",
+                    fieldset: {
+                        legend: {
+                        text: "Move on category",
+                        classes: "govuk-fieldset__legend--m"
+                        }
+                    },
+                    items: [
+                        {
+                            text: "B&B",
+                            value: "b&b"
+                        },
+                        {
+                            text: "Custody",
+                            value: "custody"
+                        },
+                        {
+                            text: "No fixed abode",
+                            value: "no-fixed-abode"
+                        },
+                        {
+                            text: "Not applicable",
+                            value: "not-applicable"
+                        },
+                        {
+                            text: "Private rented",
+                            value: "private-rented"
+                        }
+                    ]
+                    }) }}
+
+                {{ govukRadios({
+                    name: "departure[destinationProvider]",
+                    id: "destinationProvider",
+                    fieldset: {
+                        legend: {
+                        text: "Destination provider",
+                        classes: "govuk-fieldset__legend--m"
+                        }
+                    },
+                    items: [
+                        {
+                            text: "East of England",
+                            value: "east-of-england"
+                        },
+                        {
+                            text: "London",
+                            value: "london"
+                        },
+                        {
+                            text: "Wales",
+                            value: "wales"
+                        },
+                        {
+                            text: "Greater Manchester",
+                            value: "greater-manchester"
+                        },
+                        {
+                            text: "Yorkshire and The Humber",
+                            value: "yorkshire-and-the-humber"
+                        }
+                    ]
+                    }) }}
+
+                {{ govukTextarea({
+                    name: "departure[notes]",
+                    id: "notes",
+                    label: {
+                    text: "Any other information"
+                    }
+                }) }}
+
+                {{ govukButton({
+                    text: "Submit"
+                }) }}
+            </form>
+
+        </div>
+    </div>
+{% endblock %}

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -108,6 +108,22 @@ stubs.push(async () =>
   }),
 )
 
+stubs.push(async () =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/departures/${guidRegex}`,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      body: JSON.stringify(departureFactory.build()),
+    },
+  }),
+)
+
 console.log('Stubbing APIs')
 
 stubs.forEach(s =>

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -7,6 +7,7 @@ import bookingFactory from '../server/testutils/factories/booking'
 import bookingStubs from './bookingStubs'
 import arrivalStubs from './arrivalStubs'
 import nonArrivalStubs from './nonArrivalStubs'
+import departureFactory from '../server/testutils/factories/departure'
 
 const stubs = []
 const guidRegex = '([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})'
@@ -90,6 +91,22 @@ stubs.push(async () =>
 )
 
 stubs.push(...bookingStubs, ...arrivalStubs, ...nonArrivalStubs)
+
+stubs.push(async () =>
+  stubFor({
+    request: {
+      method: 'POST',
+      urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/departures`,
+    },
+    response: {
+      status: 201,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      body: JSON.stringify(departureFactory.build()),
+    },
+  }),
+)
 
 console.log('Stubbing APIs')
 

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -9,6 +9,7 @@ import arrivalStubs from './arrivalStubs'
 import nonArrivalStubs from './nonArrivalStubs'
 
 const stubs = []
+const guidRegex = '([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})'
 
 stubs.push(async () =>
   stubFor({
@@ -76,7 +77,7 @@ stubs.push(async () =>
   stubFor({
     request: {
       method: 'GET',
-      urlPathPattern: `/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`,
+      urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}`,
     },
     response: {
       status: 200,


### PR DESCRIPTION
# Context
We need to be able to communicate that a current resident has departed the AP.

For now this will be done by clicking 'Manage' against their name in the list of current residents in the Premises detail view. 'Manage' is perhaps not the best verb for now but functionality will be added later to enable multiple actions on a residents booking so will make more sense once this work is completed.
Once 'Manage' has been clicked the user has to fill in a form. As with all forms in this repo so far no validation is performed on the data as validation will be handled by the API.
Once the form has been filled in the user is taken to a confirmation page which confirms the details they have just submitted. 

There isn't any error handling in this PR as it will be completed later.

The form uses radio buttons for some of the inputs which mean the form takes up a lot of vertical space. I believe this is preferable to `select` inputs for usability and accessibility reasons and [GDS guidance states that select inputs should only be used as 'a last resort'](https://design-system.service.gov.uk/components/select/)

On the confirmation page the value of the radio button is presented back to the user as opposed to the more human-readable 'text' property of the input. Later work will included pulling in the values of these radio buttons dynamically from the API so I suggest that once that is done we display the 'text' property - but for now I think it will cause more short term work that will need to be redone in the medium term.

[Trello ticket](https://trello.com/c/xCzYhBuA/535-create-a-departure)

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/44123869/182823356-68f6d57c-f435-42b8-8a1e-2f0b01ea0665.png)


### After
![image](https://user-images.githubusercontent.com/44123869/182636451-34095476-79dc-49d0-91dd-6d9af8f683da.png)
