### PR TITLE
(496) Handling validation errors

### DIFF
--- a/integration_tests/e2e/arrivals.cy.ts
+++ b/integration_tests/e2e/arrivals.cy.ts
@@ -47,6 +47,31 @@ context('Arrivals', () => {
     PremisesShowPage.verifyOnPage(PremisesShowPage, premises)
   })
 
+  it('show errors when the API returns an error', () => {
+    // Given I am logged in
+    cy.signIn()
+
+    // And I have a booking for a premises
+    const premises = premisesFactory.build()
+    const bookingId = 'some-uuid'
+
+    cy.task('stubSinglePremises', premises)
+
+    // When I visit the arrivals page
+    const page = ArrivalCreatePage.visit(premises.id, bookingId)
+
+    // And I miss a required field
+    cy.task('stubArrivalErrors', {
+      premisesId: premises.id,
+      bookingId,
+      params: ['date', 'expectedDepartureDate'],
+    })
+    page.submitArrivalFormWithoutFields()
+
+    // Then I should see error messages relating to that field
+    page.shouldShowErrorMessagesForFields(['date', 'expectedDepartureDate'])
+  })
+
   it('creates a non-arrival', () => {
     // Given I am logged in
     cy.signIn()

--- a/integration_tests/e2e/arrivals.cy.ts
+++ b/integration_tests/e2e/arrivals.cy.ts
@@ -47,7 +47,7 @@ context('Arrivals', () => {
     PremisesShowPage.verifyOnPage(PremisesShowPage, premises)
   })
 
-  it('show errors when the API returns an error', () => {
+  it('show arrival errors when the API returns an error', () => {
     // Given I am logged in
     cy.signIn()
 
@@ -103,5 +103,30 @@ context('Arrivals', () => {
 
     // And I should be redirected to the premises page
     PremisesShowPage.verifyOnPage(PremisesShowPage, premises)
+  })
+
+  it('show non-arrival errors when the API returns an error', () => {
+    // Given I am logged in
+    cy.signIn()
+
+    // And I have a booking for a premises
+    const premises = premisesFactory.build()
+    const bookingId = 'some-uuid'
+
+    cy.task('stubSinglePremises', premises)
+
+    // When I visit the arrivals page
+    const page = ArrivalCreatePage.visit(premises.id, bookingId)
+
+    // And I miss a required field
+    cy.task('stubNonArrivalErrors', {
+      premisesId: premises.id,
+      bookingId,
+      params: ['date', 'reason'],
+    })
+    page.submitNonArrivalFormWithoutFields()
+
+    // Then I should see error messages relating to that field
+    page.shouldShowErrorMessagesForFields(['date', 'reason'])
   })
 })

--- a/integration_tests/e2e/booking.cy.ts
+++ b/integration_tests/e2e/booking.cy.ts
@@ -49,4 +49,25 @@ context('Booking', () => {
       expect(requestBody.keyWorker).equal('55126a32-0d27-4044-bc4e-e21c01632e56')
     })
   })
+
+  it('should show errors', () => {
+    const premises = premisesFactory.build()
+    cy.task('stubSinglePremises', { premisesId: premises.id })
+
+    // Given I am signed in
+    cy.signIn()
+
+    // When I visit the booking page
+    const page = BookingPage.visit(premises.id)
+
+    // And I miss a required field
+    cy.task('stubBookingErrors', {
+      premisesId: premises.id,
+      params: ['CRN', 'name', 'arrivalDate', 'expectedDepartureDate', 'keyWorker'],
+    })
+    page.clickSubmit()
+
+    // Then I should see error messages relating to that field
+    page.shouldShowErrorMessagesForFields(['CRN', 'name', 'arrivalDate', 'expectedDepartureDate', 'keyWorker'])
+  })
 })

--- a/integration_tests/mockApis/arrival.ts
+++ b/integration_tests/mockApis/arrival.ts
@@ -3,6 +3,7 @@ import { SuperAgentRequest } from 'superagent'
 import type { Arrival } from 'approved-premises'
 
 import { stubFor, getMatchingRequests } from '../../wiremock'
+import { errorStub } from '../../wiremock/utils'
 
 export default {
   stubArrivalCreate: (args: { premisesId: string; bookingId: string; arrival: Arrival }): SuperAgentRequest =>
@@ -17,6 +18,8 @@ export default {
         jsonBody: args.arrival,
       },
     }),
+  stubArrivalErrors: (args: { premisesId: string; bookingId: string; params: Array<string> }): SuperAgentRequest =>
+    stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/arrivals`)),
   verifyArrivalCreate: async (args: { premisesId: string; bookingId: string }) =>
     (
       await getMatchingRequests({

--- a/integration_tests/mockApis/booking.ts
+++ b/integration_tests/mockApis/booking.ts
@@ -1,6 +1,7 @@
 import type { Booking } from 'approved-premises'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
+import { errorStub } from '../../wiremock/utils'
 
 export default {
   stubBookingCreate: (args: { premisesId: string; booking: Booking }) =>
@@ -18,29 +19,7 @@ export default {
       },
     }),
   stubBookingErrors: (args: { premisesId: string; params: Array<string> }) =>
-    stubFor({
-      request: {
-        method: 'POST',
-        url: `/premises/${args.premisesId}/bookings`,
-      },
-      response: {
-        status: 400,
-        headers: {
-          'Content-Type': 'application/problem+json;charset=UTF-8',
-        },
-        jsonBody: {
-          type: 'https://example.net/validation-error',
-          title: 'Invalid request parameters',
-          code: 400,
-          'invalid-params': args.params.map(param => {
-            return {
-              propertyName: param,
-              errorType: 'blank',
-            }
-          }),
-        },
-      },
-    }),
+    stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings`)),
   stubBookingGet: (args: { premisesId: string; booking: Booking }) =>
     stubFor({
       request: {

--- a/integration_tests/mockApis/booking.ts
+++ b/integration_tests/mockApis/booking.ts
@@ -17,6 +17,30 @@ export default {
         jsonBody: args.booking,
       },
     }),
+  stubBookingErrors: (args: { premisesId: string; params: Array<string> }) =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: `/premises/${args.premisesId}/bookings`,
+      },
+      response: {
+        status: 400,
+        headers: {
+          'Content-Type': 'application/problem+json;charset=UTF-8',
+        },
+        jsonBody: {
+          type: 'https://example.net/validation-error',
+          title: 'Invalid request parameters',
+          code: 400,
+          'invalid-params': args.params.map(param => {
+            return {
+              propertyName: param,
+              errorType: 'blank',
+            }
+          }),
+        },
+      },
+    }),
   stubBookingGet: (args: { premisesId: string; booking: Booking }) =>
     stubFor({
       request: {

--- a/integration_tests/mockApis/nonArrival.ts
+++ b/integration_tests/mockApis/nonArrival.ts
@@ -3,6 +3,7 @@ import { SuperAgentRequest } from 'superagent'
 import type { NonArrival } from 'approved-premises'
 
 import { stubFor, getMatchingRequests } from '../../wiremock'
+import { errorStub } from '../../wiremock/utils'
 
 export default {
   stubNonArrivalCreate: (args: { premisesId: string; bookingId: string; nonArrival: NonArrival }): SuperAgentRequest =>
@@ -17,6 +18,8 @@ export default {
         jsonBody: args.nonArrival,
       },
     }),
+  stubNonArrivalErrors: (args: { premisesId: string; bookingId: string; params: Array<string> }): SuperAgentRequest =>
+    stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/non-arrivals`, ['reason'])),
   verifyNonArrivalCreate: async (args: { premisesId: string; bookingId: string }) =>
     (
       await getMatchingRequests({

--- a/integration_tests/pages/arrivalCreate.ts
+++ b/integration_tests/pages/arrivalCreate.ts
@@ -50,4 +50,9 @@ export default class ArrivalCreatePage extends Page {
 
     cy.get('[name="nonArrival[submit]"]').click()
   }
+
+  public submitArrivalFormWithoutFields(): void {
+    cy.get('input[name="arrived"][value="Yes"]').check()
+    cy.get('[name="arrival[submit]"]').click()
+  }
 }

--- a/integration_tests/pages/arrivalCreate.ts
+++ b/integration_tests/pages/arrivalCreate.ts
@@ -55,4 +55,9 @@ export default class ArrivalCreatePage extends Page {
     cy.get('input[name="arrived"][value="Yes"]').check()
     cy.get('[name="arrival[submit]"]').click()
   }
+
+  public submitNonArrivalFormWithoutFields(): void {
+    cy.get('input[name="arrived"][value="No"]').check()
+    cy.get('[name="nonArrival[submit]"]').click()
+  }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -1,3 +1,5 @@
+import errorLookups from '../../server/i18n/en/errors.json'
+
 export type PageElement = Cypress.Chainable<JQuery>
 
 export default abstract class Page {
@@ -16,4 +18,11 @@ export default abstract class Page {
   signOut = (): PageElement => cy.get('[data-qa=signOut]')
 
   manageDetails = (): PageElement => cy.get('[data-qa=manageDetails]')
+
+  shouldShowErrorMessagesForFields(fields: Array<string>): void {
+    fields.forEach(field => {
+      cy.get('.govuk-error-summary').should('contain', errorLookups[field]?.blank)
+      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups[field]?.blank)
+    })
+  }
 }

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": ["es5", "dom", "es2015.promise"],
     "types": ["cypress", "approved-premises"],
     "esModuleInterop": true,
-    "typeRoots": ["../server/@types", "../node_modules/@types"]
+    "typeRoots": ["../server/@types", "../node_modules/@types"],
+    "resolveJsonModule": true
   },
   "include": ["**/*.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
       }
     },
     "testMatch": [
-      "<rootDir>/(server|job)/**/?(*.)(cy|test).{ts,js,jsx,mjs}"
+      "<rootDir>/(server|job)/**/?(*.)(cy|test).{ts,js,jsx,mjs}",
+      "<rootDir>/wiremock/?(*.)(cy|test).{ts,js,jsx,mjs}"
     ],
     "testEnvironment": "node",
     "reporters": [

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -57,6 +57,21 @@ declare module 'approved-premises' {
   export type GroupedListofBookings = {
     [K in 'arrivingToday' | 'departingToday' | 'upcomingArrivals' | 'upcomingDepartures']: Array<TableRow>
   }
+
+  export interface ErrorMessages {
+    [K: string]: {
+      text: string
+      attributes: {
+        [K: string]: boolean
+      }
+    }
+  }
+
+  export interface ErrorSummary {
+    text: string
+    href: string
+  }
+
   export interface schemas {
     Premises: {
       id: string

--- a/server/controllers/arrivalsController.ts
+++ b/server/controllers/arrivalsController.ts
@@ -3,6 +3,7 @@ import type { Arrival, ArrivalDto } from 'approved-premises'
 
 import { convertDateInputsToIsoString } from '../utils/utils'
 import ArrivalService from '../services/arrivalService'
+import renderWithErrors from '../utils/renderWithErrors'
 
 export default class ArrivalsController {
   constructor(private readonly arrivalService: ArrivalService) {}
@@ -16,7 +17,7 @@ export default class ArrivalsController {
   }
 
   create(): RequestHandler {
-    return (req: Request, res: Response) => {
+    return async (req: Request, res: Response) => {
       const { premisesId, bookingId } = req.params
       const body = req.body as ArrivalDto
 
@@ -29,9 +30,13 @@ export default class ArrivalsController {
         expectedDepartureDate,
       }
 
-      this.arrivalService.createArrival(premisesId, bookingId, arrival)
+      try {
+        await this.arrivalService.createArrival(premisesId, bookingId, arrival)
 
-      res.redirect(`/premises/${premisesId}`)
+        res.redirect(`/premises/${premisesId}`)
+      } catch (err) {
+        renderWithErrors(req, res, err, `arrivals/new`, { premisesId, bookingId, arrived: true })
+      }
     }
   }
 }

--- a/server/controllers/bookingsController.ts
+++ b/server/controllers/bookingsController.ts
@@ -3,6 +3,7 @@ import type { Request, Response, RequestHandler } from 'express'
 
 import BookingService from '../services/bookingService'
 import { convertDateInputsToIsoString } from '../utils/utils'
+import renderWithErrors from '../utils/renderWithErrors'
 
 export default class BookingsController {
   constructor(private readonly bookingService: BookingService) {}
@@ -25,9 +26,13 @@ export default class BookingsController {
         ...convertDateInputsToIsoString(req.body, 'expectedDepartureDate'),
       }
 
-      const confirmedBooking = await this.bookingService.postBooking(premisesId as string, booking)
+      try {
+        const confirmedBooking = await this.bookingService.postBooking(premisesId as string, booking)
 
-      return res.redirect(`/premises/${premisesId}/bookings/${confirmedBooking.id}/confirmation`)
+        res.redirect(`/premises/${premisesId}/bookings/${confirmedBooking.id}/confirmation`)
+      } catch (err) {
+        renderWithErrors(req, res, err, `premises/bookings/new`, { premisesId })
+      }
     }
   }
 

--- a/server/controllers/nonArrivalsController.ts
+++ b/server/controllers/nonArrivalsController.ts
@@ -2,12 +2,13 @@ import { Response, Request, RequestHandler } from 'express'
 import type { NonArrival, NonArrivalDto } from 'approved-premises'
 import { convertDateInputsToIsoString } from '../utils/utils'
 import NonArrivalService from '../services/nonArrivalService'
+import renderWithErrors from '../utils/renderWithErrors'
 
 export default class NonArrivalsController {
   constructor(private readonly nonArrivalService: NonArrivalService) {}
 
   create(): RequestHandler {
-    return (req: Request, res: Response) => {
+    return async (req: Request, res: Response) => {
       const { premisesId, bookingId } = req.params
       const body = req.body as NonArrivalDto
       const { nonArrivalDate } = convertDateInputsToIsoString(body, 'nonArrivalDate')
@@ -17,9 +18,13 @@ export default class NonArrivalsController {
         date: nonArrivalDate,
       }
 
-      this.nonArrivalService.createNonArrival(premisesId, bookingId, nonArrival)
+      try {
+        await this.nonArrivalService.createNonArrival(premisesId, bookingId, nonArrival)
 
-      res.redirect(`/premises/${premisesId}`)
+        res.redirect(`/premises/${premisesId}`)
+      } catch (err) {
+        renderWithErrors(req, res, err, `arrivals/new`, { premisesId, bookingId, arrived: false })
+      }
     }
   }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -11,6 +11,9 @@
   "date": {
     "blank": "You must enter a valid departure date"
   },
+  "reason": {
+    "blank": "You must choose a valid reason"
+  },
   "expectedDepartureDate": {
     "blank": "You must enter a valid expected departure date"
   },

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -8,6 +8,9 @@
   "arrivalDate": {
     "blank": "You must enter a valid arrival date"
   },
+  "date": {
+    "blank": "You must enter a valid departure date"
+  },
   "expectedDepartureDate": {
     "blank": "You must enter a valid expected departure date"
   },

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -1,0 +1,17 @@
+{
+  "CRN": {
+    "blank": "You must enter a CRN"
+  },
+  "name": {
+    "blank": "You must enter a name"
+  },
+  "arrivalDate": {
+    "blank": "You must enter a valid arrival date"
+  },
+  "expectedDepartureDate": {
+    "blank": "You must enter a valid expected departure date"
+  },
+  "keyWorker": {
+    "blank": "You must choose a keyworker"
+  }
+}

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -2,7 +2,7 @@
 
 import type { ResponseError } from 'superagent'
 
-interface SanitisedError {
+export interface SanitisedError {
   text?: string
   status?: number
   headers?: unknown

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -1,0 +1,73 @@
+import { createMock } from '@golevelup/ts-jest'
+
+import type { ErrorMessages } from 'approved-premises'
+import dateFieldValues from './formUtils'
+
+describe('formUtils', () => {
+  describe('dateFieldValues', () => {
+    it('returns items with an error class when errors are present for the field', () => {
+      const errors = createMock<ErrorMessages>({
+        myField: {
+          text: 'Some error message',
+        },
+      })
+      const context = {
+        'myField-day': 12,
+        'myField-month': 11,
+        'myField-year': 2022,
+      }
+      const fieldName = 'myField'
+
+      expect(dateFieldValues(fieldName, context, errors)).toEqual([
+        {
+          classes: 'govuk-input--width-2 govuk-input--error',
+          name: 'day',
+          value: context['myField-day'],
+        },
+        {
+          classes: 'govuk-input--width-2 govuk-input--error',
+          name: 'month',
+          value: context['myField-month'],
+        },
+        {
+          classes: 'govuk-input--width-4 govuk-input--error',
+          name: 'year',
+          value: context['myField-year'],
+        },
+      ])
+    })
+
+    it('returns items without an error class when no errors are present for the field', () => {
+      const errors = createMock<ErrorMessages>({
+        someOtherField: {
+          text: 'Some error message',
+        },
+        myField: undefined,
+      })
+      const context = {
+        'myField-day': 12,
+        'myField-month': 11,
+        'myField-year': 2022,
+      }
+      const fieldName = 'myField'
+
+      expect(dateFieldValues(fieldName, context, errors)).toEqual([
+        {
+          classes: 'govuk-input--width-2 ',
+          name: 'day',
+          value: context['myField-day'],
+        },
+        {
+          classes: 'govuk-input--width-2 ',
+          name: 'month',
+          value: context['myField-month'],
+        },
+        {
+          classes: 'govuk-input--width-4 ',
+          name: 'year',
+          value: context['myField-year'],
+        },
+      ])
+    })
+  })
+})

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -1,0 +1,26 @@
+import type { ErrorMessages } from 'approved-premises'
+
+export default function dateFieldValues(
+  fieldName: string,
+  context: Record<string, unknown>,
+  errors: ErrorMessages = {},
+) {
+  const errorClass = errors[fieldName] ? 'govuk-input--error' : ''
+  return [
+    {
+      classes: `govuk-input--width-2 ${errorClass}`,
+      name: 'day',
+      value: context[`${fieldName}-day`],
+    },
+    {
+      classes: `govuk-input--width-2 ${errorClass}`,
+      name: 'month',
+      value: context[`${fieldName}-month`],
+    },
+    {
+      classes: `govuk-input--width-4 ${errorClass}`,
+      name: 'year',
+      value: context[`${fieldName}-year`],
+    },
+  ]
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -4,7 +4,10 @@
 import nunjucks from 'nunjucks'
 import express from 'express'
 import * as pathModule from 'path'
+
+import type { ErrorMessages } from 'approved-premises'
 import { initialiseName } from './utils'
+import dateFieldValues from './formUtils'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -41,4 +44,10 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   )
 
   njkEnv.addFilter('initialiseName', initialiseName)
+  njkEnv.addGlobal('dateFieldValues', dateFieldValues)
+
+  // eslint-disable-next-line func-names
+  njkEnv.addGlobal('dateFieldValues', function (fieldName: string, errors: ErrorMessages) {
+    return dateFieldValues(fieldName, this.ctx, errors)
+  })
 }

--- a/server/utils/renderWithErrors.test.ts
+++ b/server/utils/renderWithErrors.test.ts
@@ -1,0 +1,80 @@
+import { Request, Response } from 'express'
+import { createMock } from '@golevelup/ts-jest'
+
+import { SanitisedError } from '../sanitisedError'
+import renderWithErrors from './renderWithErrors'
+import errorLookups from '../i18n/en/errors.json'
+
+jest.mock('../i18n/en/errors.json', () => {
+  return {
+    CRN: {
+      blank: 'You must enter a CRN',
+    },
+    arrivalDate: {
+      blank: 'You must enter a valid arrival date',
+    },
+  }
+})
+
+describe('renderWithErrors', () => {
+  const request = createMock<Request>({})
+  const response = createMock<Response>()
+  const error = createMock<SanitisedError>({
+    data: {
+      'invalid-params': [
+        {
+          propertyName: 'CRN',
+          errorType: 'blank',
+        },
+        {
+          propertyName: 'arrivalDate',
+          errorType: 'blank',
+        },
+      ],
+    },
+  })
+
+  const expectedErrors = {
+    CRN: { text: errorLookups.CRN.blank, attributes: { 'data-cy-error-CRN': true } },
+    arrivalDate: { text: errorLookups.arrivalDate.blank, attributes: { 'data-cy-error-arrivalDate': true } },
+  }
+
+  const expectedErrorSummary = [
+    { text: errorLookups.CRN.blank, href: '#CRN' },
+    { text: errorLookups.arrivalDate.blank, href: '#arrivalDate' },
+  ]
+
+  it('renders a template with errors and the request body', () => {
+    request.body = {
+      some: 'field',
+    }
+
+    renderWithErrors(request, response, error, 'some/template')
+
+    expect(response.render).toHaveBeenCalledWith('some/template', {
+      errors: expectedErrors,
+      errorSummary: expectedErrorSummary,
+      ...request.body,
+    })
+  })
+
+  it('allows additional options to be passed to the render method', () => {
+    request.body = {
+      some: 'field',
+    }
+
+    renderWithErrors(request, response, error, 'some/template', { something: 'else' })
+
+    expect(response.render).toHaveBeenCalledWith('some/template', {
+      errors: expectedErrors,
+      errorSummary: expectedErrorSummary,
+      ...request.body,
+      something: 'else',
+    })
+  })
+
+  it('throws the error if the error is not the type we expect', () => {
+    const err = new Error()
+    expect(() => renderWithErrors(request, response, err, 'some/template', { something: 'else' })).toThrowError(err)
+  })
+})

--- a/server/utils/renderWithErrors.ts
+++ b/server/utils/renderWithErrors.ts
@@ -1,0 +1,53 @@
+import type { Response, Request } from 'express'
+
+import type { ErrorMessages, ErrorSummary } from 'approved-premises'
+import { SanitisedError } from '../sanitisedError'
+import errorLookup from '../i18n/en/errors.json'
+
+interface InvalidParams {
+  propertyName: string
+  errorType: string
+}
+
+export default function renderWithErrors(
+  request: Request,
+  response: Response,
+  error: SanitisedError | Error,
+  template: string,
+  options: Record<string, unknown> = {},
+): void {
+  if ('data' in error) {
+    const invalidParams = error.data['invalid-params']
+    const errors = generateErrorMessages(invalidParams)
+    const errorSummary = generateErrorSummary(invalidParams)
+
+    response.render(template, { errors, errorSummary, ...options, ...request.body })
+  } else {
+    throw error
+  }
+}
+
+const generateErrorMessages = (params: Array<InvalidParams>): ErrorMessages => {
+  return params.reduce((obj, error) => {
+    return {
+      ...obj,
+      [error.propertyName]: {
+        text: summaryForError(error).text,
+        attributes: {
+          [`data-cy-error-${error.propertyName}`]: true,
+        },
+      },
+    }
+  }, {})
+}
+
+const generateErrorSummary = (params: Array<InvalidParams>): Array<ErrorSummary> => {
+  return params.map(obj => summaryForError(obj))
+}
+
+const summaryForError = (error: InvalidParams): ErrorSummary => {
+  return {
+    text: errorLookup[error.propertyName][error.errorType],
+    href: `#${error.propertyName}`,
+  }
+}

--- a/server/views/arrivals/_arrival_form.njk
+++ b/server/views/arrivals/_arrival_form.njk
@@ -9,6 +9,8 @@
         classes: "govuk-fieldset__legend--m"
         }
     },
+    items: dateFieldValues('date', errors),
+    errorMessage: errors.date,
     hint: {
         text: "For example, 27 3 2007"
     }
@@ -23,8 +25,10 @@
         classes: "govuk-fieldset__legend--m"
         }
     },
+    items: dateFieldValues('expectedDepartureDate', errors),
+    errorMessage: errors.expectedDepartureDate,
     hint: {
-    text: "For example, 27 3 2007"
+      text: "For example, 27 3 2007"
     }
   }) }}
 

--- a/server/views/arrivals/_non-arrival_form.njk
+++ b/server/views/arrivals/_non-arrival_form.njk
@@ -9,6 +9,8 @@
         classes: "govuk-fieldset__legend--m"
         }
     },
+    items: dateFieldValues('date', errors),
+    errorMessage: errors.date,
     hint: {
         text: "For example, 27 3 2007"
     }
@@ -22,6 +24,7 @@
       classes: "govuk-fieldset__legend--m"
     }
   },
+  errorMessage: errors.reason,
   items: [
     {
       value: "absconded",

--- a/server/views/arrivals/new.njk
+++ b/server/views/arrivals/new.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "../partials/showErrorSummary.njk" import showErrorSummary %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -12,6 +13,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+
+      {{ showErrorSummary(errorSummary) }}
 
       {% set arrivalHTML %}
       {% include "./_arrival_form.njk" %}
@@ -37,6 +40,7 @@
               {
                 value: "Yes",
                 text: "Yes",
+                checked: arrived,
                 conditional: {
                   html: arrivalHTML
                 }

--- a/server/views/arrivals/new.njk
+++ b/server/views/arrivals/new.njk
@@ -40,7 +40,7 @@
               {
                 value: "Yes",
                 text: "Yes",
-                checked: arrived,
+                checked: arrived === true,
                 conditional: {
                   html: arrivalHTML
                 }
@@ -48,6 +48,7 @@
               {
                 value: "No",
                 text: "No",
+                checked: arrived === false,
                 conditional: {
                   html: nonArrivalHTML
                 }

--- a/server/views/partials/showErrorSummary.njk
+++ b/server/views/partials/showErrorSummary.njk
@@ -1,0 +1,12 @@
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% macro showErrorSummary(errorList) %}
+
+  {% if errorList %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errorList
+    }) }}
+  {% endif %}
+
+{% endmacro %}

--- a/server/views/premises/bookings/new.njk
+++ b/server/views/premises/bookings/new.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -17,6 +18,8 @@
             <form action="/premises/{{premisesId}}/bookings" method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
+                {{ showErrorSummary(errorSummary) }}
+
                 {{ govukInput({
                     label: {
                         text: "CRN",
@@ -24,7 +27,9 @@
                     },
                     classes: "govuk-input--width-10",
                     id: "CRN",
-                    name: "CRN"
+                    name: "CRN",
+                    value: CRN,
+                    errorMessage: errors.CRN
                 }) }}
 
                 {{ govukInput({
@@ -34,7 +39,8 @@
                     },
                     classes: "govuk-input--width-10",
                     id: "name",
-                    name: "name"
+                    name: "name",
+                    errorMessage: errors.name
                 }) }}
 
                 {{ govukDateInput({
@@ -48,7 +54,9 @@
                     },
                     hint: {
                         text: "For example, 27 3 2007"
-                    }
+                    },
+                    items: dateFieldValues('arrivalDate', errors),
+                    errorMessage: errors.arrivalDate
                 }) }}
 
                 {{ govukDateInput({
@@ -62,7 +70,9 @@
                     },
                     hint: {
                     text: "For example, 27 3 2007"
-                    }
+                    },
+                    items: dateFieldValues('expectedDepartureDate', errors),
+                    errorMessage: errors.expectedDepartureDate
                 }) }}
 
                 {{ govukSelect({
@@ -75,6 +85,11 @@
                     name: "keyWorker",
                     items: [
                         {
+                        value: "",
+                        text: "Select a keyworker",
+                        selected: keyWorker === ''
+                        },
+                        {
                         value: "bda42ec2-2435-47da-bb7f-54e90eda78b2",
                         text: "George Frank"
                         },
@@ -86,7 +101,8 @@
                         value: "cddb4be3-f0ef-4889-b987-61e1777ab17c",
                         text: "Jo Longford"
                         }
-                    ]
+                    ],
+                    errorMessage: errors.keyWorker
                 }) }}
 
                 {{ govukButton({

--- a/wiremock/arrivalStubs.ts
+++ b/wiremock/arrivalStubs.ts
@@ -1,0 +1,36 @@
+import { stubFor } from './index'
+import arrivalFactory from '../server/testutils/factories/arrival'
+import { getCombinations, errorStub } from './utils'
+
+const arrivalStubs = [
+  async () =>
+    stubFor({
+      request: {
+        method: 'POST',
+        urlPathPattern:
+          '/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/arrivals',
+      },
+      response: {
+        status: 201,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: JSON.stringify(arrivalFactory.build()),
+      },
+    }),
+]
+
+const requiredFields = getCombinations(['date', 'expectedDepartureDate'])
+
+requiredFields.forEach((fields: Array<string>) => {
+  arrivalStubs.push(async () =>
+    stubFor(
+      errorStub(
+        fields,
+        '/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/arrivals',
+      ),
+    ),
+  )
+})
+
+export default arrivalStubs

--- a/wiremock/bookingStubs.ts
+++ b/wiremock/bookingStubs.ts
@@ -1,0 +1,91 @@
+import { stubFor } from './index'
+import bookingDtoFactory from '../server/testutils/factories/bookingDto'
+
+const getCombinations = (arr: Array<string>) => {
+  const result: Array<Array<string>> = []
+  const f = (prefixes: Array<string>, suffixes: Array<string>) => {
+    for (let i = 0; i < suffixes.length; i += 1) {
+      result.push([...prefixes, suffixes[i]])
+      f(
+        [...prefixes, suffixes[i]],
+        suffixes.filter(suffix => suffixes.indexOf(suffix) !== i),
+      )
+    }
+  }
+  f([], arr)
+  return result
+}
+
+const errorStub = (fields: Array<string>) => {
+  const bodyPatterns = fields.map(field => {
+    return {
+      matchesJsonPath: `$.[?(@.${field} === '')]`,
+    }
+  })
+
+  const invalidParams = fields.map(field => {
+    return {
+      propertyName: field,
+      errorType: 'blank',
+    }
+  })
+
+  return {
+    request: {
+      method: 'POST',
+      urlPathPattern: `/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings`,
+      bodyPatterns,
+    },
+    response: {
+      status: 400,
+      headers: {
+        'Content-Type': 'application/problem+json;charset=UTF-8',
+      },
+      jsonBody: {
+        type: 'https://example.net/validation-error',
+        title: 'Invalid request parameters',
+        code: 400,
+        'invalid-params': invalidParams,
+      },
+    },
+  }
+}
+
+const bookingStubs = [
+  async () =>
+    stubFor({
+      request: {
+        method: 'POST',
+        urlPathPattern: `/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings`,
+        bodyPatterns: [
+          {
+            matchesJsonPath: "$.[?(@.CRN != '')]",
+          },
+          {
+            matchesJsonPath: "$.[?(@.arrivalDate != '')]",
+          },
+          {
+            matchesJsonPath: "$.[?(@.expectedDepartureDate != '')]",
+          },
+          {
+            matchesJsonPath: "$.[?(@.keyWorker != '')]",
+          },
+        ],
+      },
+      response: {
+        status: 201,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        body: JSON.stringify(bookingDtoFactory.build()),
+      },
+    }),
+]
+
+const requiredFields = getCombinations(['CRN', 'name', 'arrivalDate', 'expectedDepartureDate', 'keyWorker'])
+
+requiredFields.forEach((fields: Array<string>) => {
+  bookingStubs.push(async () => stubFor(errorStub(fields)))
+})
+
+export default bookingStubs

--- a/wiremock/bookingStubs.ts
+++ b/wiremock/bookingStubs.ts
@@ -1,55 +1,6 @@
 import { stubFor } from './index'
 import bookingDtoFactory from '../server/testutils/factories/bookingDto'
-
-const getCombinations = (arr: Array<string>) => {
-  const result: Array<Array<string>> = []
-  const f = (prefixes: Array<string>, suffixes: Array<string>) => {
-    for (let i = 0; i < suffixes.length; i += 1) {
-      result.push([...prefixes, suffixes[i]])
-      f(
-        [...prefixes, suffixes[i]],
-        suffixes.filter(suffix => suffixes.indexOf(suffix) !== i),
-      )
-    }
-  }
-  f([], arr)
-  return result
-}
-
-const errorStub = (fields: Array<string>) => {
-  const bodyPatterns = fields.map(field => {
-    return {
-      matchesJsonPath: `$.[?(@.${field} === '')]`,
-    }
-  })
-
-  const invalidParams = fields.map(field => {
-    return {
-      propertyName: field,
-      errorType: 'blank',
-    }
-  })
-
-  return {
-    request: {
-      method: 'POST',
-      urlPathPattern: `/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings`,
-      bodyPatterns,
-    },
-    response: {
-      status: 400,
-      headers: {
-        'Content-Type': 'application/problem+json;charset=UTF-8',
-      },
-      jsonBody: {
-        type: 'https://example.net/validation-error',
-        title: 'Invalid request parameters',
-        code: 400,
-        'invalid-params': invalidParams,
-      },
-    },
-  }
-}
+import { getCombinations, errorStub } from './utils'
 
 const bookingStubs = [
   async () =>
@@ -85,7 +36,9 @@ const bookingStubs = [
 const requiredFields = getCombinations(['CRN', 'name', 'arrivalDate', 'expectedDepartureDate', 'keyWorker'])
 
 requiredFields.forEach((fields: Array<string>) => {
-  bookingStubs.push(async () => stubFor(errorStub(fields)))
+  bookingStubs.push(async () =>
+    stubFor(errorStub(fields, `/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings`)),
+  )
 })
 
 export default bookingStubs

--- a/wiremock/nonArrivalStubs.ts
+++ b/wiremock/nonArrivalStubs.ts
@@ -1,0 +1,45 @@
+import { stubFor } from './index'
+import nonArrivalFactory from '../server/testutils/factories/nonArrival'
+import { getCombinations, errorStub } from './utils'
+
+const nonArrivalStubs = [
+  async () =>
+    stubFor({
+      request: {
+        method: 'POST',
+        urlPathPattern:
+          '/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/non-arrivals',
+        bodyPatterns: [
+          {
+            matchesJsonPath: "$.[?(@.date != '')]",
+          },
+          {
+            matchesJsonPath: "$.[?(@.reason != '')]",
+          },
+        ],
+      },
+      response: {
+        status: 201,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: JSON.stringify(nonArrivalFactory.build()),
+      },
+    }),
+]
+
+const requiredFields = getCombinations(['date', 'reason'])
+
+requiredFields.forEach((fields: Array<string>) => {
+  nonArrivalStubs.push(async () =>
+    stubFor(
+      errorStub(
+        fields,
+        '/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/non-arrivals',
+        ['reason'],
+      ),
+    ),
+  )
+})
+
+export default nonArrivalStubs

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -7,6 +7,7 @@ import arrivalFactory from '../server/testutils/factories/arrival'
 import nonArrivalFactory from '../server/testutils/factories/nonArrival'
 
 import bookingStubs from './bookingStubs'
+import arrivalStubs from './arrivalStubs'
 
 const stubs = []
 
@@ -93,23 +94,6 @@ stubs.push(async () =>
     request: {
       method: 'POST',
       urlPathPattern:
-        '/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/arrivals',
-    },
-    response: {
-      status: 201,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: JSON.stringify(arrivalFactory.build()),
-    },
-  }),
-)
-
-stubs.push(async () =>
-  stubFor({
-    request: {
-      method: 'POST',
-      urlPathPattern:
         '/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/non-arrivals',
     },
     response: {
@@ -122,7 +106,7 @@ stubs.push(async () =>
   }),
 )
 
-stubs.push(...bookingStubs)
+stubs.push(...bookingStubs, ...arrivalStubs)
 
 console.log('Stubbing APIs')
 

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -3,11 +3,10 @@ import { stubFor } from './index'
 
 import premises from './stubs/premises.json'
 import bookingFactory from '../server/testutils/factories/booking'
-import arrivalFactory from '../server/testutils/factories/arrival'
-import nonArrivalFactory from '../server/testutils/factories/nonArrival'
 
 import bookingStubs from './bookingStubs'
 import arrivalStubs from './arrivalStubs'
+import nonArrivalStubs from './nonArrivalStubs'
 
 const stubs = []
 
@@ -89,24 +88,7 @@ stubs.push(async () =>
   }),
 )
 
-stubs.push(async () =>
-  stubFor({
-    request: {
-      method: 'POST',
-      urlPathPattern:
-        '/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/non-arrivals',
-    },
-    response: {
-      status: 201,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: JSON.stringify(nonArrivalFactory.build()),
-    },
-  }),
-)
-
-stubs.push(...bookingStubs, ...arrivalStubs)
+stubs.push(...bookingStubs, ...arrivalStubs, ...nonArrivalStubs)
 
 console.log('Stubbing APIs')
 

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -2,10 +2,11 @@
 import { stubFor } from './index'
 
 import premises from './stubs/premises.json'
-import bookingDtoFactory from '../server/testutils/factories/bookingDto'
 import bookingFactory from '../server/testutils/factories/booking'
 import arrivalFactory from '../server/testutils/factories/arrival'
 import nonArrivalFactory from '../server/testutils/factories/nonArrival'
+
+import bookingStubs from './bookingStubs'
 
 const stubs = []
 
@@ -74,22 +75,6 @@ premises.forEach(p => {
 stubs.push(async () =>
   stubFor({
     request: {
-      method: 'POST',
-      urlPathPattern: `/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings`,
-    },
-    response: {
-      status: 201,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      body: JSON.stringify(bookingDtoFactory.build()),
-    },
-  }),
-)
-
-stubs.push(async () =>
-  stubFor({
-    request: {
       method: 'GET',
       urlPathPattern: `/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`,
     },
@@ -136,6 +121,8 @@ stubs.push(async () =>
     },
   }),
 )
+
+stubs.push(...bookingStubs)
 
 console.log('Stubbing APIs')
 

--- a/wiremock/utils.test.ts
+++ b/wiremock/utils.test.ts
@@ -1,0 +1,27 @@
+import { getCombinations } from './utils'
+
+describe('utils', () => {
+  describe('getCombinations', () => {
+    it('returns all the possible combinations of an array', () => {
+      const arr = ['foo', 'bar', 'baz']
+
+      expect(getCombinations(arr)).toEqual([
+        ['foo'],
+        ['foo', 'bar'],
+        ['foo', 'bar', 'baz'],
+        ['foo', 'baz'],
+        ['foo', 'baz', 'bar'],
+        ['bar'],
+        ['bar', 'foo'],
+        ['bar', 'foo', 'baz'],
+        ['bar', 'baz'],
+        ['bar', 'baz', 'foo'],
+        ['baz'],
+        ['baz', 'foo'],
+        ['baz', 'foo', 'bar'],
+        ['baz', 'bar'],
+        ['baz', 'bar', 'foo'],
+      ])
+    })
+  })
+})

--- a/wiremock/utils.ts
+++ b/wiremock/utils.ts
@@ -13,8 +13,16 @@ const getCombinations = (arr: Array<string>) => {
   return result
 }
 
-const errorStub = (fields: Array<string>, pattern: string) => {
+const errorStub = (fields: Array<string>, pattern: string, nullifiedFields: Array<string> = []) => {
   const bodyPatterns = fields.map(field => {
+    if (nullifiedFields.includes(field)) {
+      return {
+        matchesJsonPath: {
+          expression: `$.${field}`,
+          absent: '(absent)',
+        },
+      }
+    }
     return {
       matchesJsonPath: `$.[?(@.${field} === '')]`,
     }

--- a/wiremock/utils.ts
+++ b/wiremock/utils.ts
@@ -1,0 +1,51 @@
+const getCombinations = (arr: Array<string>) => {
+  const result: Array<Array<string>> = []
+  const f = (prefixes: Array<string>, suffixes: Array<string>) => {
+    for (let i = 0; i < suffixes.length; i += 1) {
+      result.push([...prefixes, suffixes[i]])
+      f(
+        [...prefixes, suffixes[i]],
+        suffixes.filter(suffix => suffixes.indexOf(suffix) !== i),
+      )
+    }
+  }
+  f([], arr)
+  return result
+}
+
+const errorStub = (fields: Array<string>, pattern: string) => {
+  const bodyPatterns = fields.map(field => {
+    return {
+      matchesJsonPath: `$.[?(@.${field} === '')]`,
+    }
+  })
+
+  const invalidParams = fields.map(field => {
+    return {
+      propertyName: field,
+      errorType: 'blank',
+    }
+  })
+
+  return {
+    request: {
+      method: 'POST',
+      urlPathPattern: pattern,
+      bodyPatterns,
+    },
+    response: {
+      status: 400,
+      headers: {
+        'Content-Type': 'application/problem+json;charset=UTF-8',
+      },
+      jsonBody: {
+        type: 'https://example.net/validation-error',
+        title: 'Invalid request parameters',
+        code: 400,
+        'invalid-params': invalidParams,
+      },
+    },
+  }
+}
+
+export { getCombinations, errorStub }


### PR DESCRIPTION
This adds the ability to cope with errors that come back from the API, we expect a `400` response, which raises an error with the body of the response. We can then rescue from the error, turn the response into something we can use to show the errors to the user, and then re-render the pages with the errrors presented.

## Screenshots

![image](https://user-images.githubusercontent.com/109774/182646701-fb79f3a0-54a8-4b11-b646-b652e144aaf5.png)

![image](https://user-images.githubusercontent.com/109774/182646771-b79f82be-f373-4c3c-ad36-4515f7495362.png)

![image](https://user-images.githubusercontent.com/109774/182646812-74dce912-7afd-494a-ae8a-7fd69df02849.png)
