### PR TITLE
Stub all APIs at once

### DIFF
--- a/wiremock/arrivalStubs.ts
+++ b/wiremock/arrivalStubs.ts
@@ -5,6 +5,7 @@ import { getCombinations, errorStub } from './utils'
 const arrivalStubs: Array<Record<string, unknown>> = []
 
 arrivalStubs.push({
+  priority: 99,
   request: {
     method: 'POST',
     urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/arrivals`,

--- a/wiremock/arrivalStubs.ts
+++ b/wiremock/arrivalStubs.ts
@@ -1,28 +1,27 @@
-import { stubFor, guidRegex } from './index'
+import { guidRegex } from './index'
 import arrivalFactory from '../server/testutils/factories/arrival'
 import { getCombinations, errorStub } from './utils'
 
-const arrivalStubs = [
-  async () =>
-    stubFor({
-      request: {
-        method: 'POST',
-        urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/arrivals`,
-      },
-      response: {
-        status: 201,
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-        },
-        jsonBody: JSON.stringify(arrivalFactory.build()),
-      },
-    }),
-]
+const arrivalStubs: Array<Record<string, unknown>> = []
+
+arrivalStubs.push({
+  request: {
+    method: 'POST',
+    urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/arrivals`,
+  },
+  response: {
+    status: 201,
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+    },
+    jsonBody: JSON.stringify(arrivalFactory.build()),
+  },
+})
 
 const requiredFields = getCombinations(['date', 'expectedDepartureDate'])
 
 requiredFields.forEach((fields: Array<string>) => {
-  arrivalStubs.push(async () => stubFor(errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/arrivals`)))
+  arrivalStubs.push(errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/arrivals`))
 })
 
 export default arrivalStubs

--- a/wiremock/bookingStubs.ts
+++ b/wiremock/bookingStubs.ts
@@ -1,42 +1,41 @@
-import { stubFor, guidRegex } from './index'
+import { guidRegex } from './index'
 import bookingDtoFactory from '../server/testutils/factories/bookingDto'
 import { getCombinations, errorStub } from './utils'
 
-const bookingStubs = [
-  async () =>
-    stubFor({
-      request: {
-        method: 'POST',
-        urlPathPattern: `/premises/${guidRegex}/bookings`,
-        bodyPatterns: [
-          {
-            matchesJsonPath: "$.[?(@.CRN != '')]",
-          },
-          {
-            matchesJsonPath: "$.[?(@.arrivalDate != '')]",
-          },
-          {
-            matchesJsonPath: "$.[?(@.expectedDepartureDate != '')]",
-          },
-          {
-            matchesJsonPath: "$.[?(@.keyWorker != '')]",
-          },
-        ],
+const bookingStubs: Array<Record<string, unknown>> = []
+
+bookingStubs.push({
+  request: {
+    method: 'POST',
+    urlPathPattern: `/premises/${guidRegex}/bookings`,
+    bodyPatterns: [
+      {
+        matchesJsonPath: "$.[?(@.CRN != '')]",
       },
-      response: {
-        status: 201,
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-        },
-        body: JSON.stringify(bookingDtoFactory.build()),
+      {
+        matchesJsonPath: "$.[?(@.arrivalDate != '')]",
       },
-    }),
-]
+      {
+        matchesJsonPath: "$.[?(@.expectedDepartureDate != '')]",
+      },
+      {
+        matchesJsonPath: "$.[?(@.keyWorker != '')]",
+      },
+    ],
+  },
+  response: {
+    status: 201,
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+    },
+    body: JSON.stringify(bookingDtoFactory.build()),
+  },
+})
 
 const requiredFields = getCombinations(['CRN', 'name', 'arrivalDate', 'expectedDepartureDate', 'keyWorker'])
 
 requiredFields.forEach((fields: Array<string>) => {
-  bookingStubs.push(async () => stubFor(errorStub(fields, `/premises/${guidRegex}/bookings`)))
+  bookingStubs.push(errorStub(fields, `/premises/${guidRegex}/bookings`))
 })
 
 export default bookingStubs

--- a/wiremock/bookingStubs.ts
+++ b/wiremock/bookingStubs.ts
@@ -5,6 +5,7 @@ import { getCombinations, errorStub } from './utils'
 const bookingStubs: Array<Record<string, unknown>> = []
 
 bookingStubs.push({
+  priority: 99,
   request: {
     method: 'POST',
     urlPathPattern: `/premises/${guidRegex}/bookings`,

--- a/wiremock/departuresStubs.ts
+++ b/wiremock/departuresStubs.ts
@@ -1,46 +1,42 @@
-import { stubFor, guidRegex } from './index'
-import { errorStub } from './utils'
+import { guidRegex } from './index'
+import { errorStub, getCombinations } from './utils'
 import departureFactory from '../server/testutils/factories/departure'
 
-const departureStubs = [
-  async () =>
-    stubFor({
-      request: {
-        method: 'POST',
-        urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/departures`,
-      },
-      response: {
-        status: 201,
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-        },
-        body: JSON.stringify(departureFactory.build()),
-      },
-    }),
+const departureStubs: Array<Record<string, unknown>> = []
 
-  async () =>
-    stubFor({
-      request: {
-        method: 'GET',
-        urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/departures/${guidRegex}`,
+departureStubs.push(
+  {
+    request: {
+      method: 'POST',
+      urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/departures`,
+    },
+    response: {
+      status: 201,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
       },
-      response: {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-        },
-        body: JSON.stringify(departureFactory.build()),
+      body: JSON.stringify(departureFactory.build()),
+    },
+  },
+  {
+    request: {
+      method: 'GET',
+      urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/departures/${guidRegex}`,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
       },
-    }),
-]
-
-departureStubs.push(async () =>
-  stubFor(
-    errorStub(
-      ['dateTime', 'destinationProvider', 'moveOnCategory', 'reason'],
-      `/premises/${guidRegex}/bookings/${guidRegex}/departures`,
-    ),
-  ),
+      body: JSON.stringify(departureFactory.build()),
+    },
+  },
 )
+
+const requiredFields = getCombinations(['dateTime', 'destinationProvider', 'moveOnCategory', 'reason'])
+
+requiredFields.forEach((fields: Array<string>) => {
+  departureStubs.push(errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/departures`))
+})
 
 export default departureStubs

--- a/wiremock/index.ts
+++ b/wiremock/index.ts
@@ -9,9 +9,12 @@ export const guidRegex = '([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a
 const stubFor = (mapping: Record<string, unknown>): SuperAgentRequest =>
   superagent.post(`${url}/mappings`).send(mapping)
 
+const bulkStub = (body: Record<string, unknown>): SuperAgentRequest =>
+  superagent.post(`${url}/__admin/mappings/import`).send(body)
+
 const getMatchingRequests = (body: object) => superagent.post(`${url}/requests/find`).send(body)
 
 const resetStubs = (): Promise<Array<Response>> =>
   Promise.all([superagent.delete(`${url}/mappings`), superagent.delete(`${url}/requests`)])
 
-export { stubFor, getMatchingRequests, resetStubs }
+export { stubFor, getMatchingRequests, resetStubs, bulkStub }

--- a/wiremock/nonArrivalStubs.ts
+++ b/wiremock/nonArrivalStubs.ts
@@ -5,6 +5,7 @@ import { getCombinations, errorStub } from './utils'
 const nonArrivalStubs: Array<Record<string, unknown>> = []
 
 nonArrivalStubs.push({
+  priority: 99,
   request: {
     method: 'POST',
     urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/non-arrivals`,

--- a/wiremock/nonArrivalStubs.ts
+++ b/wiremock/nonArrivalStubs.ts
@@ -1,38 +1,35 @@
-import { stubFor, guidRegex } from './index'
+import { guidRegex } from './index'
 import nonArrivalFactory from '../server/testutils/factories/nonArrival'
 import { getCombinations, errorStub } from './utils'
 
-const nonArrivalStubs = [
-  async () =>
-    stubFor({
-      request: {
-        method: 'POST',
-        urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/non-arrivals`,
-        bodyPatterns: [
-          {
-            matchesJsonPath: "$.[?(@.date != '')]",
-          },
-          {
-            matchesJsonPath: "$.[?(@.reason != '')]",
-          },
-        ],
+const nonArrivalStubs: Array<Record<string, unknown>> = []
+
+nonArrivalStubs.push({
+  request: {
+    method: 'POST',
+    urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/non-arrivals`,
+    bodyPatterns: [
+      {
+        matchesJsonPath: "$.[?(@.date != '')]",
       },
-      response: {
-        status: 201,
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-        },
-        jsonBody: JSON.stringify(nonArrivalFactory.build()),
+      {
+        matchesJsonPath: "$.[?(@.reason != '')]",
       },
-    }),
-]
+    ],
+  },
+  response: {
+    status: 201,
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+    },
+    jsonBody: JSON.stringify(nonArrivalFactory.build()),
+  },
+})
 
 const requiredFields = getCombinations(['date', 'reason'])
 
 requiredFields.forEach((fields: Array<string>) => {
-  nonArrivalStubs.push(async () =>
-    stubFor(errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/non-arrivals`, ['reason'])),
-  )
+  nonArrivalStubs.push(errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/non-arrivals`, ['reason']))
 })
 
 export default nonArrivalStubs

--- a/wiremock/utils.test.ts
+++ b/wiremock/utils.test.ts
@@ -3,24 +3,24 @@ import { getCombinations } from './utils'
 describe('utils', () => {
   describe('getCombinations', () => {
     it('returns all the possible combinations of an array', () => {
-      const arr = ['foo', 'bar', 'baz']
+      const arr = ['CRN', 'name', 'arrivalDate', 'expectedDepartureDate', 'keyWorker']
 
       expect(getCombinations(arr)).toEqual([
-        ['foo'],
-        ['foo', 'bar'],
-        ['foo', 'bar', 'baz'],
-        ['foo', 'baz'],
-        ['foo', 'baz', 'bar'],
-        ['bar'],
-        ['bar', 'foo'],
-        ['bar', 'foo', 'baz'],
-        ['bar', 'baz'],
-        ['bar', 'baz', 'foo'],
-        ['baz'],
-        ['baz', 'foo'],
-        ['baz', 'foo', 'bar'],
-        ['baz', 'bar'],
-        ['baz', 'bar', 'foo'],
+        ['CRN', 'name', 'arrivalDate', 'expectedDepartureDate', 'keyWorker'],
+        ['CRN', 'name', 'arrivalDate', 'expectedDepartureDate'],
+        ['name', 'arrivalDate', 'expectedDepartureDate', 'keyWorker'],
+        ['CRN', 'name', 'arrivalDate'],
+        ['name', 'arrivalDate', 'expectedDepartureDate'],
+        ['arrivalDate', 'expectedDepartureDate', 'keyWorker'],
+        ['CRN', 'name'],
+        ['name', 'arrivalDate'],
+        ['arrivalDate', 'expectedDepartureDate'],
+        ['expectedDepartureDate', 'keyWorker'],
+        ['CRN'],
+        ['name'],
+        ['arrivalDate'],
+        ['expectedDepartureDate'],
+        ['keyWorker'],
       ])
     })
   })

--- a/wiremock/utils.ts
+++ b/wiremock/utils.ts
@@ -1,16 +1,14 @@
 const getCombinations = (arr: Array<string>) => {
   const result: Array<Array<string>> = []
-  const f = (prefixes: Array<string>, suffixes: Array<string>) => {
-    for (let i = 0; i < suffixes.length; i += 1) {
-      result.push([...prefixes, suffixes[i]])
-      f(
-        [...prefixes, suffixes[i]],
-        suffixes.filter(suffix => suffixes.indexOf(suffix) !== i),
-      )
+  arr.forEach(item => {
+    result.push([item])
+    const index = arr.indexOf(item) + 1
+    for (let i = index; i < arr.length; i += 1) {
+      const group = [item, ...arr.slice(index, i + 1)]
+      result.push(group)
     }
-  }
-  f([], arr)
-  return result
+  })
+  return result.sort((a, b) => b.length - a.length)
 }
 
 const errorStub = (fields: Array<string>, pattern: string, nullifiedFields: Array<string> = []) => {


### PR DESCRIPTION
Before we were stubbing each individual stub in a seperate request, which Wiremock struggled with sometimes, now we’re using the Bulk Import API (https://wiremock.org/docs/stubbing/#bulk-importing-stubs), which sends them all in one HTTP request, which is much faster and more reliable.