### PR TITLE
(552) Departure error handling

### DIFF
--- a/integration_tests/e2e/departure.cy.ts
+++ b/integration_tests/e2e/departure.cy.ts
@@ -55,4 +55,36 @@ context('Departures', () => {
 
     departureConfirmationPage.verifyConfirmedDepartureIsVisible(departure, booking)
   })
+  it('should show errors', () => {
+    const premises = premisesFactory.buildList(5)
+    const booking = bookingFactory.build()
+    const departure = departureFactory.build({
+      dateTime: new Date(2022, 1, 11, 12, 35).toISOString(),
+      reason: 'other',
+      destinationAp: premises[2].name,
+      moveOnCategory: 'private-rented',
+      destinationProvider: 'yorkshire-and-the-humber',
+    })
+
+    // Given I am signed in
+    cy.task('stubPremises', premises)
+    cy.task('stubBookingGet', { premisesId: premises[0].id, booking })
+    cy.task('stubDepartureGet', { premisesId: premises[0].id, bookingId: booking.id, departure })
+    cy.signIn()
+
+    // When I visit the departure page
+    const page = DepartureCreatePage.visit(premises[0].id, booking.id)
+
+    // And I miss a required field
+    cy.task('stubDepartureErrors', {
+      premisesId: premises[0].id,
+      bookingId: booking.id,
+      params: ['dateTime', 'destinationProvider', 'moveOnCategory', 'reason'],
+    })
+
+    page.clickSubmit()
+
+    // Then I should see error messages relating to that field
+    page.shouldShowErrorMessagesForFields(['dateTime', 'reason', 'moveOnCategory', 'destinationProvider'])
+  })
 })

--- a/integration_tests/mockApis/departure.ts
+++ b/integration_tests/mockApis/departure.ts
@@ -3,6 +3,7 @@ import { SuperAgentRequest } from 'superagent'
 import type { Departure } from 'approved-premises'
 
 import { stubFor, getMatchingRequests } from '../../wiremock'
+import { errorStub } from '../../wiremock/utils'
 
 export default {
   stubDepartureGet: (args: { premisesId: string; bookingId: string; departure: Departure }): SuperAgentRequest =>
@@ -29,6 +30,15 @@ export default {
         jsonBody: args.departure,
       },
     }),
+  stubDepartureErrors: (args: { premisesId: string; bookingId: string; params: Array<string> }) =>
+    stubFor(
+      errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/departures`, [
+        'notes',
+        'destinationProvider',
+        'moveOnCategory',
+        'reason',
+      ]),
+    ),
   verifyDepartureCreate: async (args: { premisesId: string; bookingId: string }) =>
     (
       await getMatchingRequests({

--- a/integration_tests/pages/departureCreate.ts
+++ b/integration_tests/pages/departureCreate.ts
@@ -36,7 +36,10 @@ export default class DepartureCreatePage extends Page {
     cy.get('input[name="departure[destinationProvider]"]').last().check()
 
     cy.get('textarea[name="departure[notes]"]').type(departure.notes)
+    this.clickSubmit()
+  }
 
+  clickSubmit() {
     cy.get('button').click()
   }
 }

--- a/server/controllers/departuresController.test.ts
+++ b/server/controllers/departuresController.test.ts
@@ -7,6 +7,9 @@ import { PremisesService } from '../services'
 import BookingService from '../services/bookingService'
 import departureFactory from '../testutils/factories/departure'
 import bookingFactory from '../testutils/factories/booking'
+import renderWithErrors from '../utils/renderWithErrors'
+
+jest.mock('../utils/renderWithErrors')
 
 describe('DeparturesController', () => {
   let request: DeepMocked<Request> = createMock<Request>({})
@@ -102,6 +105,31 @@ describe('DeparturesController', () => {
       expect(response.redirect).toHaveBeenCalledWith(
         `/premises/premisesId/bookings/bookingId/departures/${departure.id}/confirmation`,
       )
+    })
+
+    it('should render the page with errors when the API returns an error', async () => {
+      const requestHandler = departuresController.create()
+
+      const premisesId = 'premisesId'
+
+      request.params = {
+        bookingId: 'bookingId',
+        premisesId,
+      }
+
+      const err = new Error()
+
+      departureService.createDeparture.mockImplementation(() => {
+        throw err
+      })
+
+      await requestHandler(request, response, next)
+
+      expect(renderWithErrors).toHaveBeenCalledWith(request, response, err, 'departures/new', {
+        booking: {},
+        premisesId,
+        premisesSelectList: {},
+      })
     })
   })
 

--- a/server/controllers/departuresController.ts
+++ b/server/controllers/departuresController.ts
@@ -5,6 +5,7 @@ import { convertDateAndTimeInputsToIsoString } from '../utils/utils'
 import DepartureService from '../services/departureService'
 import PremisesService from '../services/premisesService'
 import BookingService from '../services/bookingService'
+import renderWithErrors from '../utils/renderWithErrors'
 
 export default class DeparturesController {
   constructor(
@@ -34,9 +35,15 @@ export default class DeparturesController {
         dateTime,
       }
 
-      const { id } = await this.departureService.createDeparture(premisesId, bookingId, departure)
+      try {
+        const { id } = await this.departureService.createDeparture(premisesId, bookingId, departure)
+        res.redirect(`/premises/${premisesId}/bookings/${bookingId}/departures/${id}/confirmation`)
+      } catch (err) {
+        const booking = await this.bookingService.getBooking(premisesId, bookingId)
+        const premisesSelectList = await this.premisesService.getPremisesSelectList()
 
-      return res.redirect(`/premises/${premisesId}/bookings/${bookingId}/departures/${id}/confirmation`)
+        renderWithErrors(req, res, err, 'departures/new', { premisesId, booking, premisesSelectList })
+      }
     }
   }
 

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -19,5 +19,10 @@
   },
   "keyWorker": {
     "blank": "You must choose a keyworker"
-  }
+  },
+  "dateTime": {
+    "blank": "You must enter a valid departure date and time"
+  },
+  "moveOnCategory": { "blank": "You must enter a move on category" },
+  "destinationProvider": { "blank": "You must enter a destination provider" }
 }

--- a/server/views/departures/new.njk
+++ b/server/views/departures/new.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "../partials/showErrorSummary.njk" import showErrorSummary %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -15,7 +16,11 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1>Log a departure</h1>
-            {{ govukSummaryList({
+
+            <form action="/premises/{{premisesId}}/bookings/{{booking.id}}/departures" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+                {{ govukSummaryList({
                 rows: [
                    {
                     key: {
@@ -36,21 +41,23 @@
                     ]
             })
             }}
-            <form action="/premises/{{premisesId}}/bookings/{{booking.id}}/departures" method="post">
-                <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+                {{ showErrorSummary(errorSummary) }}
 
                 {{ govukDateInput({
                     id: "dateTime",
                     namePrefix: "dateTime",
                     fieldset: {
-                    legend: {
-                        text: "What is the departure date?",
-                        classes: "govuk-fieldset__legend--m"
-                        }
+                        legend: {
+                            text: "What is the departure date?",
+                            classes: "govuk-fieldset__legend--m"
+                            }
                     },
                     hint: {
                         text: "For example, 27 3 2007"
-                    }
+                    },
+                    errorMessage: errors.dateTime,
+                    items: dateFieldValues('dateTime', errors)
                 }) }}
 
                 <label class="govuk-label govuk-label--m" for="time">
@@ -65,7 +72,8 @@
                         text: "Destination Approved Premises",
                         classes: "govuk-label govuk-label--m"
                         },
-                    items: premisesSelectList
+                    items: premisesSelectList,
+                    errorMessage: errors.expectedDepartureDate
                     }) }}
 
                 {{ govukRadios({
@@ -77,6 +85,7 @@
                         classes: "govuk-fieldset__legend--m"
                         }
                     },
+                    errorMessage: errors.reason,
                     items: [
                         {
                             text: "Absconded",
@@ -110,6 +119,7 @@
                         classes: "govuk-fieldset__legend--m"
                         }
                     },
+                    errorMessage: errors.moveOnCategory,
                     items: [
                         {
                             text: "B&B",
@@ -143,6 +153,7 @@
                         classes: "govuk-fieldset__legend--m"
                         }
                     },
+                    errorMessage: errors.destinationProvider,
                     items: [
                         {
                             text: "East of England",

--- a/wiremock/arrivalStubs.ts
+++ b/wiremock/arrivalStubs.ts
@@ -1,4 +1,4 @@
-import { stubFor } from './index'
+import { stubFor, guidRegex } from './index'
 import arrivalFactory from '../server/testutils/factories/arrival'
 import { getCombinations, errorStub } from './utils'
 
@@ -7,8 +7,7 @@ const arrivalStubs = [
     stubFor({
       request: {
         method: 'POST',
-        urlPathPattern:
-          '/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/arrivals',
+        urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/arrivals`,
       },
       response: {
         status: 201,
@@ -23,14 +22,7 @@ const arrivalStubs = [
 const requiredFields = getCombinations(['date', 'expectedDepartureDate'])
 
 requiredFields.forEach((fields: Array<string>) => {
-  arrivalStubs.push(async () =>
-    stubFor(
-      errorStub(
-        fields,
-        '/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/arrivals',
-      ),
-    ),
-  )
+  arrivalStubs.push(async () => stubFor(errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/arrivals`)))
 })
 
 export default arrivalStubs

--- a/wiremock/bookingStubs.ts
+++ b/wiremock/bookingStubs.ts
@@ -1,4 +1,4 @@
-import { stubFor } from './index'
+import { stubFor, guidRegex } from './index'
 import bookingDtoFactory from '../server/testutils/factories/bookingDto'
 import { getCombinations, errorStub } from './utils'
 
@@ -7,7 +7,7 @@ const bookingStubs = [
     stubFor({
       request: {
         method: 'POST',
-        urlPathPattern: `/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings`,
+        urlPathPattern: `/premises/${guidRegex}/bookings`,
         bodyPatterns: [
           {
             matchesJsonPath: "$.[?(@.CRN != '')]",
@@ -36,9 +36,7 @@ const bookingStubs = [
 const requiredFields = getCombinations(['CRN', 'name', 'arrivalDate', 'expectedDepartureDate', 'keyWorker'])
 
 requiredFields.forEach((fields: Array<string>) => {
-  bookingStubs.push(async () =>
-    stubFor(errorStub(fields, `/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings`)),
-  )
+  bookingStubs.push(async () => stubFor(errorStub(fields, `/premises/${guidRegex}/bookings`)))
 })
 
 export default bookingStubs

--- a/wiremock/departuresStubs.ts
+++ b/wiremock/departuresStubs.ts
@@ -1,33 +1,46 @@
 import { stubFor, guidRegex } from './index'
-
+import { errorStub } from './utils'
 import departureFactory from '../server/testutils/factories/departure'
 
-export default [
-  stubFor({
-    request: {
-      method: 'POST',
-      urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/departures`,
-    },
-    response: {
-      status: 201,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
+const departureStubs = [
+  async () =>
+    stubFor({
+      request: {
+        method: 'POST',
+        urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/departures`,
       },
-      body: JSON.stringify(departureFactory.build()),
-    },
-  }),
+      response: {
+        status: 201,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        body: JSON.stringify(departureFactory.build()),
+      },
+    }),
 
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/departures/${guidRegex}`,
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
+  async () =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/departures/${guidRegex}`,
       },
-      body: JSON.stringify(departureFactory.build()),
-    },
-  }),
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        body: JSON.stringify(departureFactory.build()),
+      },
+    }),
 ]
+
+departureStubs.push(async () =>
+  stubFor(
+    errorStub(
+      ['dateTime', 'destinationProvider', 'moveOnCategory', 'reason'],
+      `/premises/${guidRegex}/bookings/${guidRegex}/departures`,
+    ),
+  ),
+)
+
+export default departureStubs

--- a/wiremock/departuresStubs.ts
+++ b/wiremock/departuresStubs.ts
@@ -1,0 +1,33 @@
+import { stubFor, guidRegex } from './index'
+
+import departureFactory from '../server/testutils/factories/departure'
+
+export default [
+  stubFor({
+    request: {
+      method: 'POST',
+      urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/departures`,
+    },
+    response: {
+      status: 201,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      body: JSON.stringify(departureFactory.build()),
+    },
+  }),
+
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/departures/${guidRegex}`,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      body: JSON.stringify(departureFactory.build()),
+    },
+  }),
+]

--- a/wiremock/index.ts
+++ b/wiremock/index.ts
@@ -4,6 +4,8 @@ const wiremockEndpoint = process.env.CYPRESS ? 'http://localhost:9091' : 'http:/
 
 const url = `${wiremockEndpoint}/__admin`
 
+export const guidRegex = '([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})'
+
 const stubFor = (mapping: Record<string, unknown>): SuperAgentRequest =>
   superagent.post(`${url}/mappings`).send(mapping)
 

--- a/wiremock/nonArrivalStubs.ts
+++ b/wiremock/nonArrivalStubs.ts
@@ -1,4 +1,4 @@
-import { stubFor } from './index'
+import { stubFor, guidRegex } from './index'
 import nonArrivalFactory from '../server/testutils/factories/nonArrival'
 import { getCombinations, errorStub } from './utils'
 
@@ -7,8 +7,7 @@ const nonArrivalStubs = [
     stubFor({
       request: {
         method: 'POST',
-        urlPathPattern:
-          '/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/non-arrivals',
+        urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/non-arrivals`,
         bodyPatterns: [
           {
             matchesJsonPath: "$.[?(@.date != '')]",
@@ -32,13 +31,7 @@ const requiredFields = getCombinations(['date', 'reason'])
 
 requiredFields.forEach((fields: Array<string>) => {
   nonArrivalStubs.push(async () =>
-    stubFor(
-      errorStub(
-        fields,
-        '/premises/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/bookings/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/non-arrivals',
-        ['reason'],
-      ),
-    ),
+    stubFor(errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/non-arrivals`, ['reason'])),
   )
 })
 

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { stubFor } from './index'
+import { stubFor, guidRegex } from './index'
 
 import premises from './stubs/premises.json'
 import bookingFactory from '../server/testutils/factories/booking'
@@ -10,7 +10,6 @@ import nonArrivalStubs from './nonArrivalStubs'
 import departureFactory from '../server/testutils/factories/departure'
 
 const stubs = []
-const guidRegex = '([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})'
 
 stubs.push(async () =>
   stubFor({

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -7,7 +7,6 @@ import bookingFactory from '../server/testutils/factories/booking'
 import bookingStubs from './bookingStubs'
 import arrivalStubs from './arrivalStubs'
 import nonArrivalStubs from './nonArrivalStubs'
-import departureFactory from '../server/testutils/factories/departure'
 
 const stubs = []
 
@@ -90,38 +89,6 @@ stubs.push(async () =>
 )
 
 stubs.push(...bookingStubs, ...arrivalStubs, ...nonArrivalStubs)
-
-stubs.push(async () =>
-  stubFor({
-    request: {
-      method: 'POST',
-      urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/departures`,
-    },
-    response: {
-      status: 201,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      body: JSON.stringify(departureFactory.build()),
-    },
-  }),
-)
-
-stubs.push(async () =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/departures/${guidRegex}`,
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      body: JSON.stringify(departureFactory.build()),
-    },
-  }),
-)
 
 console.log('Stubbing APIs')
 


### PR DESCRIPTION
# Context
We need to be able to show errors when the form fields are submitted without the data we need on the departures form.

[Trello ticket](https://trello.com/c/9UXVb7jA/552-departure-error-handling)

# Changes in this PR
This PR closely follows the patterns outlined in @pezholio's [earlier error handling PR](https://github.com/ministryofjustice/approved-premises-ui/pull/53). 
The only issue with this I see is that the time input doesn't have the same errors showing despite being a necessary field. We're using nunjucks macros from the GDS DS for all the inputs apart from time and I ran out of time to implement something similar for it. But this is a start.



## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/44123869/183091735-5b05f683-5d56-4d14-9f68-e4ba048b096e.png)