### PR TITLE
Tweaks for deployment

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,5 +14,7 @@ generic-service:
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
 
+  allowlist: null
+
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -5,12 +5,12 @@ generic-service:
   replicaCount: 2
 
   ingress:
-    host: approved-premises-ui-dev.hmpps.service.justice.gov.uk
+    host: approved-premises-dev.hmpps.service.justice.gov.uk
     contextColour: green
 
   env:
     APPROVED_PREMISES_API_URL: 'https://approved-premises-api-dev.hmpps.service.justice.gov.uk'
-    INGRESS_URL: 'https://approved-premises-ui-dev.hmpps.service.justice.gov.uk'
+    INGRESS_URL: 'https://approved-premises-dev.hmpps.service.justice.gov.uk'
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
 


### PR DESCRIPTION
I accidentally specified the hostname as `approved-premises-ui-dev`, rather than just `approved-premises-dev`. The certificate is named correctly in cloud-platform, so doesn't need to be changed. I've also turned off the IP restrictions for dev.