### PR TITLE
Change certificate secret name

### DIFF
--- a/helm_deploy/approved-premises-ui/values.yaml
+++ b/helm_deploy/approved-premises-ui/values.yaml
@@ -6,13 +6,13 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/approved-premises-ui
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 3000
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
-    tlsSecretName: approved-premises-ui-cert
+    host: app-hostname.local # override per environment
+    tlsSecretName: approved-premises-ui-cert # override per environment
 
   livenessProbe:
     httpGet:
@@ -30,10 +30,10 @@ generic-service:
 
   # Environment variables to load into the deployment
   env:
-    NODE_ENV: "production"
-    REDIS_TLS_ENABLED: "true"
-    TOKEN_VERIFICATION_ENABLED: "true"
-    APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"
+    NODE_ENV: 'production'
+    REDIS_TLS_ENABLED: 'true'
+    TOKEN_VERIFICATION_ENABLED: 'true'
+    APPLICATIONINSIGHTS_CONNECTION_STRING: 'InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/'
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
@@ -42,25 +42,25 @@ generic-service:
 
   namespace_secrets:
     approved-premises-ui:
-      APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
-      API_CLIENT_ID: "API_CLIENT_ID"
-      API_CLIENT_SECRET: "API_CLIENT_SECRET"
-      SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
-      SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
-      SESSION_SECRET: "SESSION_SECRET"
+      APPINSIGHTS_INSTRUMENTATIONKEY: 'APPINSIGHTS_INSTRUMENTATIONKEY'
+      API_CLIENT_ID: 'API_CLIENT_ID'
+      API_CLIENT_SECRET: 'API_CLIENT_SECRET'
+      SYSTEM_CLIENT_ID: 'SYSTEM_CLIENT_ID'
+      SYSTEM_CLIENT_SECRET: 'SYSTEM_CLIENT_SECRET'
+      SESSION_SECRET: 'SESSION_SECRET'
     elasticache-redis:
-      REDIS_HOST: "primary_endpoint_address"
-      REDIS_AUTH_TOKEN: "auth_token"
+      REDIS_HOST: 'primary_endpoint_address'
+      REDIS_AUTH_TOKEN: 'auth_token'
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
+    office: '217.33.148.210/32'
+    health-kick: '35.177.252.195/32'
+    petty-france-wifi: '213.121.161.112/28'
+    global-protect: '35.176.93.186/32'
+    mojvpn: '81.134.202.29/32'
+    cloudplatform-live1-1: '35.178.209.113/32'
+    cloudplatform-live1-2: '3.8.51.207/32'
+    cloudplatform-live1-3: '35.177.252.54/32'
 
 generic-prometheus-alerts:
   targetApplication: approved-premises-ui

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,6 +7,7 @@ generic-service:
   ingress:
     host: approved-premises-dev.hmpps.service.justice.gov.uk
     contextColour: green
+    tlsSecretName: approved-premises-dev-cert
 
   env:
     APPROVED_PREMISES_API_URL: 'https://approved-premises-api-dev.hmpps.service.justice.gov.uk'


### PR DESCRIPTION
This was named incorrectly, so renaming here to be consistent with the naming in cloud-platform. Also made it clear that this should be overriden on a per environment basis.