### PR TITLE
Make sure dates are formatted consistently

### DIFF
--- a/integration_tests/pages/bookingConfirmation.ts
+++ b/integration_tests/pages/bookingConfirmation.ts
@@ -1,5 +1,6 @@
 import parseISO from 'date-fns/parseISO'
 import type { Booking } from 'approved-premises'
+import { formatDate } from '../../server/utils/utils'
 import Page from './page'
 
 export default class BookingConfirmationPage extends Page {
@@ -16,11 +17,8 @@ export default class BookingConfirmationPage extends Page {
     cy.get('dl').within(() => {
       this.assertDefinition('Name', booking.name)
       this.assertDefinition('CRN', booking.CRN)
-      this.assertDefinition('Arrival date', parseISO(booking.arrivalDate).toLocaleDateString('en-GB'))
-      this.assertDefinition(
-        'Expected departure date',
-        parseISO(booking.expectedDepartureDate).toLocaleDateString('en-GB'),
-      )
+      this.assertDefinition('Arrival date', formatDate(parseISO(booking.arrivalDate)))
+      this.assertDefinition('Expected departure date', formatDate(parseISO(booking.expectedDepartureDate)))
       this.assertDefinition('Key worker', booking.keyWorker)
     })
   }

--- a/integration_tests/pages/premisesShow.ts
+++ b/integration_tests/pages/premisesShow.ts
@@ -3,6 +3,7 @@ import { parseISO } from 'date-fns'
 import type { Premises, Booking } from 'approved-premises'
 
 import Page from './page'
+import { formatDate } from '../../server/utils/utils'
 
 export default class PremisesShowPage extends Page {
   constructor(private readonly premises: Premises) {
@@ -72,7 +73,7 @@ export default class PremisesShowPage extends Page {
       cy.contains(item.CRN)
         .parent()
         .within(() => {
-          cy.get('td').eq(0).contains(date.toLocaleDateString('en-GB'))
+          cy.get('td').eq(0).contains(formatDate(date))
           cy.get('td')
             .eq(1)
             .contains('Manage')
@@ -87,7 +88,9 @@ export default class PremisesShowPage extends Page {
       cy.contains(item.CRN)
         .parent()
         .within(() => {
-          cy.get('td').eq(0).contains(parseISO(item.expectedDepartureDate).toLocaleDateString('en-GB'))
+          cy.get('td')
+            .eq(0)
+            .contains(formatDate(parseISO(item.expectedDepartureDate)))
           cy.get('td')
             .eq(1)
             .contains('Manage')

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -3,6 +3,7 @@ import BookingClient from '../data/bookingClient'
 
 import bookingDtoFactory from '../testutils/factories/bookingDto'
 import bookingFactory from '../testutils/factories/booking'
+import { formatDate } from '../utils/utils'
 
 jest.mock('../data/bookingClient.ts')
 
@@ -31,36 +32,47 @@ describe('BookingService', () => {
 
   describe('getBooking', () => {
     it('on success returns the booking that has been requested', async () => {
+      const arrivalDate = new Date(2022, 2, 11)
+      const expectedDepartureDate = new Date(2022, 2, 12)
+
       const booking = bookingFactory.build({
-        arrivalDate: new Date(2022, 2, 11).toISOString(),
-        expectedDepartureDate: new Date(2022, 2, 12).toISOString(),
+        arrivalDate: arrivalDate.toISOString(),
+        expectedDepartureDate: expectedDepartureDate.toISOString(),
       })
 
       bookingClient.getBooking.mockResolvedValue(booking)
 
       const retrievedBooking = await service.getBooking('premisesId', booking.id)
-      expect(retrievedBooking).toEqual({ ...booking, arrivalDate: '11/03/2022', expectedDepartureDate: '12/03/2022' })
+      expect(retrievedBooking).toEqual({
+        ...booking,
+        arrivalDate: formatDate(arrivalDate),
+        expectedDepartureDate: formatDate(expectedDepartureDate),
+      })
     })
   })
 
   describe('bookingsToTableRows', () => {
     it('should convert bookings to table rows with an arrival date', () => {
       const premisesId = 'some-uuid'
+
+      const booking1Date = new Date(2022, 10, 22)
+      const booking2Date = new Date(2022, 2, 11)
+
       const bookings = [
-        bookingFactory.build({ arrivalDate: new Date(2022, 10, 22).toISOString() }),
-        bookingFactory.build({ arrivalDate: new Date(2022, 2, 11).toISOString() }),
+        bookingFactory.build({ arrivalDate: booking1Date.toISOString() }),
+        bookingFactory.build({ arrivalDate: booking2Date.toISOString() }),
       ]
 
       const results = service.bookingsToTableRows(bookings, premisesId, 'arrival')
 
       expect(results[0][0]).toEqual({ text: bookings[0].CRN })
-      expect(results[0][1]).toEqual({ text: '22/11/2022' })
+      expect(results[0][1]).toEqual({ text: formatDate(booking1Date) })
       expect(results[0][2]).toEqual({
         html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[0].id}/arrivals/new`),
       })
 
       expect(results[1][0]).toEqual({ text: bookings[1].CRN })
-      expect(results[1][1]).toEqual({ text: '11/03/2022' })
+      expect(results[1][1]).toEqual({ text: formatDate(booking2Date) })
       expect(results[1][2]).toEqual({
         html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[1].id}/arrivals/new`),
       })
@@ -68,21 +80,25 @@ describe('BookingService', () => {
 
     it('should convert bookings to table rows with a departure date', () => {
       const premisesId = 'some-uuid'
+
+      const booking1Date = new Date(2022, 10, 22)
+      const booking2Date = new Date(2022, 2, 11)
+
       const bookings = [
-        bookingFactory.build({ expectedDepartureDate: new Date(2022, 10, 22).toISOString() }),
-        bookingFactory.build({ expectedDepartureDate: new Date(2022, 2, 11).toISOString() }),
+        bookingFactory.build({ expectedDepartureDate: booking1Date.toISOString() }),
+        bookingFactory.build({ expectedDepartureDate: booking2Date.toISOString() }),
       ]
 
       const results = service.bookingsToTableRows(bookings, premisesId, 'departure')
 
       expect(results[0][0]).toEqual({ text: bookings[0].CRN })
-      expect(results[0][1]).toEqual({ text: '22/11/2022' })
+      expect(results[0][1]).toEqual({ text: formatDate(booking1Date) })
       expect(results[0][2]).toEqual({
         html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[0].id}/arrivals/new`),
       })
 
       expect(results[1][0]).toEqual({ text: bookings[1].CRN })
-      expect(results[1][1]).toEqual({ text: '11/03/2022' })
+      expect(results[1][1]).toEqual({ text: formatDate(booking2Date) })
       expect(results[1][2]).toEqual({
         html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[1].id}/arrivals/new`),
       })

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -4,7 +4,7 @@ import type { Booking, BookingDto, TableRow, GroupedListofBookings } from 'appro
 
 import type { RestClientBuilder } from '../data'
 import BookingClient from '../data/bookingClient'
-import { convertDateString } from '../utils/utils'
+import { convertDateString, formatDate } from '../utils/utils'
 
 export default class BookingService {
   UPCOMING_WINDOW_IN_DAYS = 5
@@ -32,8 +32,8 @@ export default class BookingService {
 
     return {
       ...booking,
-      arrivalDate: parseISO(booking.arrivalDate).toLocaleDateString('en-GB'),
-      expectedDepartureDate: parseISO(booking.expectedDepartureDate).toLocaleDateString('en-GB'),
+      arrivalDate: formatDate(parseISO(booking.arrivalDate)),
+      expectedDepartureDate: formatDate(parseISO(booking.expectedDepartureDate)),
     }
   }
 
@@ -67,9 +67,7 @@ export default class BookingService {
         text: booking.CRN,
       },
       {
-        text: convertDateString(
-          type === 'arrival' ? booking.arrivalDate : booking.expectedDepartureDate,
-        ).toLocaleDateString('en-GB'),
+        text: formatDate(convertDateString(type === 'arrival' ? booking.arrivalDate : booking.expectedDepartureDate)),
       },
       {
         html: `<a href="/premises/${premisesId}/bookings/${booking.id}/arrivals/new">
@@ -98,7 +96,7 @@ export default class BookingService {
         text: booking.CRN,
       },
       {
-        text: convertDateString(booking.expectedDepartureDate).toLocaleDateString('en-GB'),
+        text: formatDate(convertDateString(booking.expectedDepartureDate)),
       },
       {
         html: `<a href="/premises/${premisesId}/bookings/${booking.id}/departures/new">

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -4,6 +4,7 @@ import {
   initialiseName,
   convertDateAndTimeInputsToIsoString,
   InvalidDateStringError,
+  formatDate,
 } from './utils'
 
 describe('convert to title case', () => {
@@ -32,6 +33,16 @@ describe('initialise name', () => {
     ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
   ])('%s initialiseName(%s, %s)', (_: string, a: string, expected: string) => {
     expect(initialiseName(a)).toEqual(expected)
+  })
+})
+
+describe('formatDate', () => {
+  it('converts a date to a GOV.UK formatted date', () => {
+    const date1 = new Date(2022, 7, 1)
+    const date2 = new Date(2022, 8, 16)
+
+    expect(formatDate(date1)).toEqual('Monday 1 August 2022')
+    expect(formatDate(date2)).toEqual('Friday 16 September 2022')
   })
 })
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,4 +1,4 @@
-import { parseISO } from 'date-fns'
+import { parseISO, format } from 'date-fns'
 import type { ObjectWithDateParts } from 'approved-premises'
 
 /* istanbul ignore next */
@@ -28,6 +28,8 @@ export const initialiseName = (fullName?: string): string | null => {
   const array = fullName.split(' ')
   return `${array[0][0]}. ${array.reverse()[0]}`
 }
+
+export const formatDate = (date: Date): string => format(date, 'cccc d MMMM y')
 
 /**
  * Converts an ISO8601 datetime string into a Javascript Date object.


### PR DESCRIPTION
Rather than dd/mm/yyyy, we should be formatting dates as per the GOV.UK style guide (https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates)

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/109774/183940579-f5619dfd-ff6d-4195-bf09-c0a5ce8da9c2.png)

## After

![image](https://user-images.githubusercontent.com/109774/183940681-bca646e2-c0bc-42fb-b837-4a1d493acbc9.png)
