### PR TITLE
Redirect with errors on validation error in arrivals

### DIFF
--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -96,6 +96,12 @@ declare module 'approved-premises' {
     href: string
   }
 
+  export interface ErrorsAndUserInput {
+    errors: ErrorMessages
+    errorSummary: Array<string>
+    userInput: Record<string, unknown>
+  }
+
   export interface schemas {
     Premises: {
       id: string

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,3 +1,5 @@
+import type { ErrorMessages } from 'approved-premises'
+
 export default {}
 
 declare module 'express-session' {
@@ -39,6 +41,7 @@ export declare global {
       verified?: boolean
       id: string
       logout(done: (err: unknown) => void): void
+      flash(type: string, message: string | ErrorMessages | Array<ErrorSummary> | Record<string, unknown>): number
     }
   }
 }

--- a/server/controllers/arrivalsController.test.ts
+++ b/server/controllers/arrivalsController.test.ts
@@ -3,9 +3,9 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
 import ArrivalService from '../services/arrivalService'
 import ArrivalsController from './arrivalsController'
-import renderWithErrors from '../utils/renderWithErrors'
+import renderWithErrors from '../utils/validation'
 
-jest.mock('../utils/renderWithErrors')
+jest.mock('../utils/validation')
 
 describe('ArrivalsController', () => {
   const request: DeepMocked<Request> = createMock<Request>({})

--- a/server/controllers/arrivalsController.ts
+++ b/server/controllers/arrivalsController.ts
@@ -3,7 +3,7 @@ import type { Arrival, ArrivalDto } from 'approved-premises'
 
 import { convertDateAndTimeInputsToIsoString } from '../utils/utils'
 import ArrivalService from '../services/arrivalService'
-import renderWithErrors from '../utils/renderWithErrors'
+import renderWithErrors from '../utils/validation'
 
 export default class ArrivalsController {
   constructor(private readonly arrivalService: ArrivalService) {}

--- a/server/controllers/arrivalsController.ts
+++ b/server/controllers/arrivalsController.ts
@@ -3,7 +3,7 @@ import type { Arrival, ArrivalDto } from 'approved-premises'
 
 import { convertDateAndTimeInputsToIsoString } from '../utils/utils'
 import ArrivalService from '../services/arrivalService'
-import renderWithErrors from '../utils/validation'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../utils/validation'
 
 export default class ArrivalsController {
   constructor(private readonly arrivalService: ArrivalService) {}
@@ -11,8 +11,9 @@ export default class ArrivalsController {
   new(): RequestHandler {
     return (req: Request, res: Response) => {
       const { premisesId, bookingId } = req.params
+      const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
-      res.render('arrivals/new', { premisesId, bookingId })
+      res.render('arrivals/new', { premisesId, bookingId, errors, errorSummary, ...userInput })
     }
   }
 
@@ -35,7 +36,7 @@ export default class ArrivalsController {
 
         res.redirect(`/premises/${premisesId}`)
       } catch (err) {
-        renderWithErrors(req, res, err, `arrivals/new`, { premisesId, bookingId, arrived: true })
+        catchValidationErrorOrPropogate(req, res, err, `/premises/${premisesId}/bookings/${bookingId}/arrivals/new`)
       }
     }
   }

--- a/server/controllers/bookingsController.test.ts
+++ b/server/controllers/bookingsController.test.ts
@@ -3,11 +3,11 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
 import BookingService from '../services/bookingService'
 import BookingsController from './bookingsController'
-import renderWithErrors from '../utils/renderWithErrors'
+import renderWithErrors from '../utils/validation'
 
 import bookingFactory from '../testutils/factories/booking'
 
-jest.mock('../utils/renderWithErrors')
+jest.mock('../utils/validation')
 
 describe('bookingsController', () => {
   let request: DeepMocked<Request> = createMock<Request>({})

--- a/server/controllers/bookingsController.ts
+++ b/server/controllers/bookingsController.ts
@@ -2,7 +2,7 @@ import type { BookingDto } from 'approved-premises'
 import type { Request, Response, RequestHandler } from 'express'
 
 import BookingService from '../services/bookingService'
-import renderWithErrors from '../utils/renderWithErrors'
+import renderWithErrors from '../utils/validation'
 import { convertDateAndTimeInputsToIsoString } from '../utils/utils'
 
 export default class BookingsController {

--- a/server/controllers/departuresController.test.ts
+++ b/server/controllers/departuresController.test.ts
@@ -7,9 +7,9 @@ import { PremisesService } from '../services'
 import BookingService from '../services/bookingService'
 import departureFactory from '../testutils/factories/departure'
 import bookingFactory from '../testutils/factories/booking'
-import renderWithErrors from '../utils/renderWithErrors'
+import renderWithErrors from '../utils/validation'
 
-jest.mock('../utils/renderWithErrors')
+jest.mock('../utils/validation')
 
 describe('DeparturesController', () => {
   let request: DeepMocked<Request> = createMock<Request>({})

--- a/server/controllers/departuresController.ts
+++ b/server/controllers/departuresController.ts
@@ -5,7 +5,7 @@ import { convertDateAndTimeInputsToIsoString } from '../utils/utils'
 import DepartureService from '../services/departureService'
 import PremisesService from '../services/premisesService'
 import BookingService from '../services/bookingService'
-import renderWithErrors from '../utils/renderWithErrors'
+import renderWithErrors from '../utils/validation'
 
 export default class DeparturesController {
   constructor(

--- a/server/controllers/nonArrivalsController.test.ts
+++ b/server/controllers/nonArrivalsController.test.ts
@@ -3,9 +3,9 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import NonArrivalService from '../services/nonArrivalService'
 
 import NonArrivalsController from './nonArrivalsController'
-import renderWithErrors from '../utils/renderWithErrors'
+import renderWithErrors from '../utils/validation'
 
-jest.mock('../utils/renderWithErrors')
+jest.mock('../utils/validation')
 
 describe('NonArrivalsController', () => {
   const request: DeepMocked<Request> = createMock<Request>({})

--- a/server/controllers/nonArrivalsController.ts
+++ b/server/controllers/nonArrivalsController.ts
@@ -2,7 +2,7 @@ import { Response, Request, RequestHandler } from 'express'
 import type { NonArrival, NonArrivalDto } from 'approved-premises'
 import { convertDateAndTimeInputsToIsoString } from '../utils/utils'
 import NonArrivalService from '../services/nonArrivalService'
-import renderWithErrors from '../utils/renderWithErrors'
+import renderWithErrors from '../utils/validation'
 
 export default class NonArrivalsController {
   constructor(private readonly nonArrivalService: NonArrivalService) {}

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -1,8 +1,9 @@
 import { Request, Response } from 'express'
 import { createMock } from '@golevelup/ts-jest'
 
+import type { ErrorMessages, ErrorSummary } from 'approved-premises'
 import { SanitisedError } from '../sanitisedError'
-import renderWithErrors, { catchValidationErrorOrPropogate } from './validation'
+import renderWithErrors, { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from './validation'
 import errorLookups from '../i18n/en/errors.json'
 
 jest.mock('../i18n/en/errors.json', () => {
@@ -124,5 +125,39 @@ describe('catchValidationErrorOrPropogate', () => {
   it('throws the error if the error is not the type we expect', () => {
     const err = new Error()
     expect(() => renderWithErrors(request, response, err, 'some/template', { something: 'else' })).toThrowError(err)
+  })
+})
+
+describe('fetchErrorsAndUserInput', () => {
+  const request = createMock<Request>({})
+
+  let errors: ErrorMessages
+  let userInput: Record<string, unknown>
+  let errorSummary: ErrorSummary
+
+  beforeEach(() => {
+    ;(request.flash as jest.Mock).mockImplementation((message: string) => {
+      return {
+        errors: [errors],
+        userInput: [userInput],
+        errorSummary,
+      }[message]
+    })
+  })
+
+  it('returns default values if there is nothing present', () => {
+    const result = fetchErrorsAndUserInput(request)
+
+    expect(result).toEqual({ errors: {}, errorSummary: [], userInput: {} })
+  })
+
+  it('fetches the values from the flash', () => {
+    errors = createMock<ErrorMessages>()
+    errorSummary = createMock<ErrorSummary>()
+    userInput = { foo: 'bar' }
+
+    const result = fetchErrorsAndUserInput(request)
+
+    expect(result).toEqual({ errors, errorSummary, userInput })
   })
 })

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -27,6 +27,27 @@ export default function renderWithErrors(
   }
 }
 
+export const catchValidationErrorOrPropogate = (
+  request: Request,
+  response: Response,
+  error: SanitisedError | Error,
+  redirectPath: string,
+): void => {
+  if ('data' in error) {
+    const invalidParams = error.data['invalid-params']
+    const errors = generateErrorMessages(invalidParams)
+    const errorSummary = generateErrorSummary(invalidParams)
+
+    request.flash('errors', errors)
+    request.flash('errorSummary', errorSummary)
+    request.flash('userInput', request.body)
+
+    response.redirect(redirectPath)
+  } else {
+    throw error
+  }
+}
+
 const generateErrorMessages = (params: Array<InvalidParams>): ErrorMessages => {
   return params.reduce((obj, error) => {
     return {

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -1,6 +1,6 @@
 import type { Response, Request } from 'express'
 
-import type { ErrorMessages, ErrorSummary } from 'approved-premises'
+import type { ErrorMessages, ErrorSummary, ErrorsAndUserInput } from 'approved-premises'
 import { SanitisedError } from '../sanitisedError'
 import errorLookup from '../i18n/en/errors.json'
 
@@ -46,6 +46,19 @@ export const catchValidationErrorOrPropogate = (
   } else {
     throw error
   }
+}
+
+export const fetchErrorsAndUserInput = (request: Request): ErrorsAndUserInput => {
+  const errors = firstFlashItem(request, 'errors') || {}
+  const errorSummary = request.flash('errorSummary') || []
+  const userInput = firstFlashItem(request, 'userInput') || {}
+
+  return { errors, errorSummary, userInput }
+}
+
+const firstFlashItem = (request: Request, key: string) => {
+  const message = request.flash(key)
+  return message ? message[0] : undefined
 }
 
 const generateErrorMessages = (params: Array<InvalidParams>): ErrorMessages => {

--- a/server/views/arrivals/_arrival_form.njk
+++ b/server/views/arrivals/_arrival_form.njk
@@ -35,6 +35,7 @@
   {{ govukTextarea({
     name: "arrival[notes]",
     id: "notes",
+    value: arrival.notes,
     label: {
       text: "Any other information"
     }

--- a/server/views/arrivals/new.njk
+++ b/server/views/arrivals/new.njk
@@ -40,7 +40,7 @@
               {
                 value: "Yes",
                 text: "Yes",
-                checked: arrived === true,
+                checked: arrival|length,
                 conditional: {
                   html: arrivalHTML
                 }
@@ -48,7 +48,7 @@
               {
                 value: "No",
                 text: "No",
-                checked: arrived === false,
+                checked: nonArrival|length,
                 conditional: {
                   html: nonArrivalHTML
                 }

--- a/server/views/partials/showErrorSummary.njk
+++ b/server/views/partials/showErrorSummary.njk
@@ -2,7 +2,7 @@
 
 {% macro showErrorSummary(errorList) %}
 
-  {% if errorList %}
+  {% if errorList | length %}
     {{ govukErrorSummary({
       titleText: "There is a problem",
       errorList: errorList


### PR DESCRIPTION
This alters the approach for error handling to redirect to the `GET` method and render errors when an error is detected. This means that we don't have to repeat ourselves when doing any setup/teardown and reduce any risk of any expensive setup operations being wasted if the error is not a validation error and ends up getting bubbled up. In the interests of keeping this PR focussed, I've used this approach in the arrivalsController for now, but if all is well, I'll use it in the other controllers too and add that to another PR.