### PR TITLE
Add a `cspNonce` to the webSecurity setup

### DIFF
--- a/doc/architecture/decisions/0004-add-a-cspnonce-variable-to-make-inlining-scripts-easier.md
+++ b/doc/architecture/decisions/0004-add-a-cspnonce-variable-to-make-inlining-scripts-easier.md
@@ -1,0 +1,41 @@
+# 4. Add a CSPNonce variable to make inlining scripts easier
+
+Date: 2022-08-12
+
+## Status
+
+Accepted
+
+## Context
+
+The Typescript template comes with some best-practice Web Security setups, that prevent
+untrusted inline JavaScript from being run in the browser, or scripts / styles from
+untrusted sources from being loaded, if, for example a man in the middle attack injects
+something into the page.
+
+This works, but makes inlining our own JavaScript difficult, something that is needed
+for using the MoJ Design System.
+
+## Decision
+
+After looking at other projects, we've noticed that other teams use the `cspNonce`
+approach, see:
+
+https://content-security-policy.com/nonce
+
+We will then generate a `cspNonce` local, that can be injected into templates. This
+variable will then be used in our content security policy to allow any code with that
+variable added to be run, e.g:
+
+```html
+<script nonce="{{ cspNonce}}">
+  // Do some inline JS here
+</script>
+```
+
+## Consequences
+
+This will make inlining our JavaScript easier, while still maintaining security. It
+will require future developers to know about the `cspNonce` approach, but hopefully
+comments in the code and this ADR will make things clearer. Inline JS also currently
+does not work with this approach, and it took a lot of digging to find out why.

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -1,5 +1,6 @@
-import express, { Router } from 'express'
+import express, { Router, Request, Response, NextFunction } from 'express'
 import helmet from 'helmet'
+import crypto from 'crypto'
 
 export default function setUpWebSecurity(): Router {
   const router = express.Router()
@@ -7,14 +8,23 @@ export default function setUpWebSecurity(): Router {
   // Secure code best practice - see:
   // 1. https://expressjs.com/en/advanced/best-practice-security.html,
   // 2. https://www.npmjs.com/package/helmet
+  router.use((_req: Request, res: Response, next: NextFunction) => {
+    res.locals.cspNonce = crypto.randomBytes(16).toString('hex')
+    next()
+  })
   router.use(
     helmet({
       contentSecurityPolicy: {
         directives: {
           defaultSrc: ["'self'"],
-          // Hash allows inline script pulled in from https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/template.njk
-          scriptSrc: ["'self'", 'code.jquery.com', "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"],
-          styleSrc: ["'self'", 'code.jquery.com'],
+          // This nonce allows us to use scripts with the use of the `cspNonce` local, e.g (in a Nunjucks template):
+          // <script nonce="{{ cspNonce }}">
+          // or
+          // <link href="http://example.com/" rel="stylesheet" nonce="{{ cspNonce }}">
+          // This ensures only scripts we trust are loaded, and not anything injected into the
+          // page by an attacker.
+          scriptSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
+          styleSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
           fontSrc: ["'self'"],
         },
       },

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -10,22 +10,23 @@
   <script src="/assets/js/html5shiv-3.7.3.min.js"></script>
   <![endif]-->
 
-  <script src="/assets/js/jquery.min.js"></script> 
+  <script src="/assets/js/jquery.min.js"></script>
   <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
           integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
+          nonce="{{ cspNonce }}"
           crossorigin="anonymous"></script>
-  <link href="https://code.jquery.com/ui/1.12.1/themes/ui-lightness/jquery-ui.css" rel="stylesheet" crossorigin>
+  <link href="https://code.jquery.com/ui/1.12.1/themes/ui-lightness/jquery-ui.css" rel="stylesheet" nonce="{{ cspNonce }}" crossorigin>
 
 {% endblock %}
 
-{% block pageTitle %}{{pageTitle | default(applicationName)}}{% endblock %}
+{% block pageTitle %}{{pageTitle | default(applicationName)}}
+{% endblock %}
 
 {% block header %}
   {% include "./header.njk" %}
 {% endblock %}
 
-{% block bodyStart %}
-{% endblock %}
+{% block bodyStart %}{% endblock %}
 
 {% block bodyEnd %}
   {# Run JavaScript at end of the


### PR DESCRIPTION
Based on what I’ve seen elsewhere, this seems to now be a common approach to allow us to inline scripts, see:

https://content-security-policy.com/nonce

The GOV.UK frontend has now been updated to support the use of the `cspNonce` local - see:

 https://github.com/alphagov/govuk-frontend/commit/2e40d744af6e6e4213ebc47644982d4eb94422d4

So we no longer need to add the inline hash, which is vulnerable to if the code in the frontend template is changed.

I’ve also removed the domain-specific overrides for jQuery scripts and styles, as we can use the nonce for this too.

If we're happy with this approach, then I'll replicate it in the Typescript template to make it easier for folks. 