### PR TITLE
Add Slack channel for alerts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
     type: string
     # Normally team specific alert channel e.g. hmpps_tech_alerts, syscon-alerts, dps_sed_alerts
     # This is to avoid a general alert dumping ground that no-one then monitors
-    default: hmpps_typescript_notifications
+    default: approved-premises-team-dev
 
   releases-slack-channel:
     type: string


### PR DESCRIPTION
This means any alerts from our CircleCI builds go to the right place