### PR TITLE
(477) Add cancellation service

### DIFF
--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -5,6 +5,7 @@ declare module 'approved-premises' {
   export type Departure = schemas['Departure']
   export type Booking = schemas['Booking']
   export type ReferenceData = schemas['ReferenceData']
+  export type Cancellation = schemas['Cancellation']
 
   export type BookingDto = Omit<Booking, 'id' | 'status' | 'arrival'>
 
@@ -33,6 +34,11 @@ declare module 'approved-premises' {
       moveOnCategory: string
       destinationProvider: string
       destinationAp: string
+    }
+
+  export type CancellationDto = Omit<Cancellation, 'id' | 'bookingId' | 'reason'> &
+    ObjectWithDateParts<'date'> & {
+      reason: string
     }
 
   export type BookingStatus = 'arrived' | 'awaiting-arrival' | 'not-arrived' | 'departed' | 'cancelled'
@@ -161,6 +167,13 @@ declare module 'approved-premises' {
       id: string
       name: string
       isActive: boolean
+    }
+    Cancellation: {
+      id: string
+      bookingId: string
+      date: string
+      reason: ReferenceData
+      notes: string
     }
   }
 }

--- a/server/data/cancellationClient.test.ts
+++ b/server/data/cancellationClient.test.ts
@@ -1,0 +1,61 @@
+import nock from 'nock'
+
+import CancellationClient from './cancellationClient'
+import config from '../config'
+import cancellationFactory from '../testutils/factories/cancellation'
+import cancellationDtoFactory from '../testutils/factories/cancellationDto'
+
+describe('cancellationClient', () => {
+  let fakeApprovedPremisesApi: nock.Scope
+  let cancellationClient: CancellationClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    config.apis.approvedPremises.url = 'http://localhost:8080'
+    fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
+    cancellationClient = new CancellationClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('create', () => {
+    it('should create a cancellation', async () => {
+      const cancellationDto = cancellationDtoFactory.build()
+      const cancellation = cancellationFactory.build()
+
+      fakeApprovedPremisesApi
+        .post(`/premises/premisesId/bookings/bookingId/cancellations`, cancellationDto)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, cancellation)
+
+      const result = await cancellationClient.create('premisesId', 'bookingId', cancellationDto)
+
+      expect(result).toEqual(cancellation)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+
+  describe('get', () => {
+    it('given a cancellation ID should return a cancellation', async () => {
+      const cancellation = cancellationFactory.build()
+
+      fakeApprovedPremisesApi
+        .get(`/premises/premisesId/bookings/bookingId/cancellations/${cancellation.id}`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, cancellation)
+
+      const result = await cancellationClient.get('premisesId', 'bookingId', cancellation.id)
+
+      expect(result).toEqual(cancellation)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+})

--- a/server/data/cancellationClient.ts
+++ b/server/data/cancellationClient.ts
@@ -1,0 +1,28 @@
+import type { Cancellation, CancellationDto } from 'approved-premises'
+import RestClient from './restClient'
+import config, { ApiConfig } from '../config'
+
+export default class CancellationClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('cancellationClient', config.apis.approvedPremises as ApiConfig, token)
+  }
+
+  async create(premisesId: string, bookingId: string, cancellation: CancellationDto): Promise<Cancellation> {
+    const response = await this.restClient.post({
+      path: `/premises/${premisesId}/bookings/${bookingId}/cancellations`,
+      data: cancellation,
+    })
+
+    return response as Cancellation
+  }
+
+  async get(premisesId: string, bookingId: string, departureId: string): Promise<Cancellation> {
+    const response = await this.restClient.get({
+      path: `/premises/${premisesId}/bookings/${bookingId}/cancellations/${departureId}`,
+    })
+
+    return response as Cancellation
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -17,6 +17,7 @@ import ArrivalClient from './arrivalClient'
 import NonArrivalClient from './nonArrivalClient'
 import DepartureClient from './departureClient'
 import ReferenceDataClient from './referenceDataClient'
+import CancellationClient from './cancellationClient'
 
 import { createRedisClient } from './redisClient'
 import TokenStore from './tokenStore'
@@ -32,6 +33,8 @@ export const dataAccess = () => ({
   departureClientBuilder: ((token: string) => new DepartureClient(token)) as RestClientBuilder<DepartureClient>,
   referenceDataClientBuilder: ((token: string) =>
     new ReferenceDataClient(token)) as RestClientBuilder<ReferenceDataClient>,
+  cancellationClientBuilder: ((token: string) =>
+    new CancellationClient(token)) as RestClientBuilder<CancellationClient>,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>
@@ -45,4 +48,5 @@ export {
   NonArrivalClient,
   DepartureClient,
   ReferenceDataClient,
+  CancellationClient,
 }

--- a/server/services/cancellationService.test.ts
+++ b/server/services/cancellationService.test.ts
@@ -1,0 +1,65 @@
+import CancellationService from './cancellationService'
+import CancellationClient from '../data/cancellationClient'
+import ReferenceDataClient from '../data/referenceDataClient'
+
+import cancellationDtoFactory from '../testutils/factories/cancellationDto'
+import cancellationFactory from '../testutils/factories/cancellation'
+import referenceDataFactory from '../testutils/factories/referenceData'
+
+jest.mock('../data/cancellationClient.ts')
+jest.mock('../data/referenceDataClient.ts')
+
+describe('DepartureService', () => {
+  const cancellationClient = new CancellationClient(null) as jest.Mocked<CancellationClient>
+  const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
+  let service: CancellationService
+
+  const CancellationClientFactory = jest.fn()
+  const ReferenceDataClientFactory = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    CancellationClientFactory.mockReturnValue(cancellationClient)
+    ReferenceDataClientFactory.mockReturnValue(referenceDataClient)
+    service = new CancellationService(CancellationClientFactory, ReferenceDataClientFactory)
+  })
+
+  describe('createCancellation', () => {
+    it('on success returns the cancellation that has been posted', async () => {
+      const cancellationDto = cancellationDtoFactory.build()
+      const cancellation = cancellationFactory.build()
+
+      cancellationClient.create.mockResolvedValue(cancellation)
+
+      const postedDeparture = await service.createCancellation('premisesId', 'bookingId', cancellationDto)
+      expect(postedDeparture).toEqual(cancellation)
+      expect(cancellationClient.create).toHaveBeenCalledWith('premisesId', 'bookingId', cancellationDto)
+    })
+  })
+
+  describe('getCancellationReasons', () => {
+    it('should return the cancellation reasons', async () => {
+      const cancellationReasons = referenceDataFactory.buildList(2)
+
+      referenceDataClient.getReferenceData.mockResolvedValue(cancellationReasons)
+
+      const result = await service.getCancellationReasons()
+
+      expect(result).toEqual(cancellationReasons)
+
+      expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('cancellation-reasons')
+    })
+  })
+
+  describe('getCancellation', () => {
+    it('on success returns the cancellation that has been requested', async () => {
+      const cancellation = cancellationFactory.build()
+      cancellationClient.get.mockResolvedValue(cancellation)
+
+      const requestedDeparture = await service.getCancellation('premisesId', 'bookingId', cancellation.id)
+
+      expect(requestedDeparture).toEqual(cancellation)
+      expect(cancellationClient.get).toHaveBeenCalledWith('premisesId', 'bookingId', cancellation.id)
+    })
+  })
+})

--- a/server/services/cancellationService.ts
+++ b/server/services/cancellationService.ts
@@ -1,0 +1,41 @@
+import type { Cancellation, CancellationDto, ReferenceData } from 'approved-premises'
+import type { RestClientBuilder, CancellationClient, ReferenceDataClient } from '../data'
+
+export default class CancellationService {
+  // TODO: We need to do some more work on authentication to work
+  // out how to get this token, so let's stub for now
+  token = 'FAKE_TOKEN'
+
+  constructor(
+    private readonly cancellationClientFactory: RestClientBuilder<CancellationClient>,
+    private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
+  ) {}
+
+  async createCancellation(
+    premisesId: string,
+    bookingId: string,
+    cancellation: CancellationDto,
+  ): Promise<Cancellation> {
+    const cancellationClient = this.cancellationClientFactory(this.token)
+
+    const confirmedCancellation = await cancellationClient.create(premisesId, bookingId, cancellation)
+
+    return confirmedCancellation
+  }
+
+  async getCancellation(premisesId: string, bookingId: string, cancellationId: string): Promise<Cancellation> {
+    const cancellationClient = this.cancellationClientFactory(this.token)
+
+    const booking = await cancellationClient.get(premisesId, bookingId, cancellationId)
+
+    return booking
+  }
+
+  async getCancellationReasons(): Promise<Array<ReferenceData>> {
+    const referenceDataClient = this.referenceDataClientFactory(this.token)
+
+    const reasons = await referenceDataClient.getReferenceData('cancellation-reasons')
+
+    return reasons as Array<ReferenceData>
+  }
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -8,6 +8,7 @@ import BookingService from './bookingService'
 import ArrivalService from './arrivalService'
 import NonArrivalService from './nonArrivalService'
 import DepartureService from './departureService'
+import CancellationService from './cancellationService'
 
 export const services = () => {
   const {
@@ -18,6 +19,7 @@ export const services = () => {
     nonArrivalClientBuilder,
     departureClientBuilder,
     referenceDataClientBuilder,
+    cancellationClientBuilder,
   } = dataAccess()
 
   const userService = new UserService(hmppsAuthClient)
@@ -26,6 +28,7 @@ export const services = () => {
   const arrivalService = new ArrivalService(arrivalClientBuilder)
   const nonArrivalService = new NonArrivalService(nonArrivalClientBuilder)
   const departureService = new DepartureService(departureClientBuilder, referenceDataClientBuilder)
+  const cancellationService = new CancellationService(cancellationClientBuilder, referenceDataClientBuilder)
 
   return {
     userService,
@@ -34,9 +37,18 @@ export const services = () => {
     arrivalService,
     nonArrivalService,
     departureService,
+    cancellationService,
   }
 }
 
 export type Services = ReturnType<typeof services>
 
-export { UserService, PremisesService, ArrivalService, NonArrivalService, DepartureService }
+export {
+  UserService,
+  PremisesService,
+  ArrivalService,
+  NonArrivalService,
+  DepartureService,
+  CancellationService,
+  BookingService,
+}

--- a/server/testutils/factories/cancellation.ts
+++ b/server/testutils/factories/cancellation.ts
@@ -1,0 +1,13 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { Cancellation } from 'approved-premises'
+import referenceDataFactory from './referenceData'
+
+export default Factory.define<Cancellation>(() => ({
+  id: faker.datatype.uuid(),
+  date: faker.date.soon().toISOString(),
+  bookingId: faker.datatype.uuid(),
+  reason: referenceDataFactory.cancellationReasons().build(),
+  notes: faker.lorem.sentence(),
+}))

--- a/server/testutils/factories/cancellationDto.ts
+++ b/server/testutils/factories/cancellationDto.ts
@@ -1,0 +1,19 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { CancellationDto } from 'approved-premises'
+import referenceDataFactory from './referenceData'
+
+export default Factory.define<CancellationDto>(() => {
+  const date = faker.date.soon()
+  return {
+    id: faker.datatype.uuid(),
+    date: faker.date.soon().toISOString(),
+    'date-day': date.getDate().toString(),
+    'date-month': date.getMonth().toString(),
+    'date-year': date.getFullYear().toString(),
+    bookingId: faker.datatype.uuid(),
+    reason: referenceDataFactory.cancellationReasons().build().id,
+    notes: faker.lorem.sentence(),
+  }
+})

--- a/server/testutils/factories/referenceData.ts
+++ b/server/testutils/factories/referenceData.ts
@@ -6,6 +6,7 @@ import type { ReferenceData } from 'approved-premises'
 import departureReasonsJson from '../../../wiremock/stubs/departure-reasons.json'
 import moveOnCategoriesJson from '../../../wiremock/stubs/move-on-categories.json'
 import destinationProvidersJson from '../../../wiremock/stubs/destination-providers.json'
+import cancellationReasonsJson from '../../../wiremock/stubs/cancellation-reasons.json'
 
 class ReferenceDataFactory extends Factory<ReferenceData> {
   departureReasons() {
@@ -20,6 +21,11 @@ class ReferenceDataFactory extends Factory<ReferenceData> {
 
   destinationProviders() {
     const data = faker.helpers.arrayElement(destinationProvidersJson)
+    return this.params(data)
+  }
+
+  cancellationReasons() {
+    const data = faker.helpers.arrayElement(cancellationReasonsJson)
     return this.params(data)
   }
 }

--- a/wiremock/cancellationStubs.ts
+++ b/wiremock/cancellationStubs.ts
@@ -1,0 +1,43 @@
+import { guidRegex } from './index'
+import cancellationFactory from '../server/testutils/factories/cancellation'
+import { getCombinations, errorStub } from './utils'
+
+const cancellationStubs: Array<Record<string, unknown>> = []
+
+cancellationStubs.push(
+  {
+    priority: 99,
+    request: {
+      method: 'POST',
+      urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/cancellations`,
+    },
+    response: {
+      status: 201,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      body: JSON.stringify(cancellationFactory.build()),
+    },
+  },
+  {
+    request: {
+      method: 'GET',
+      urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/cancellations/${guidRegex}`,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      body: JSON.stringify(cancellationFactory.build()),
+    },
+  },
+)
+
+const requiredFields = getCombinations(['date', 'reason'])
+
+requiredFields.forEach((fields: Array<string>) => {
+  cancellationStubs.push(errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/cancellations`, ['reason']))
+})
+
+export default cancellationStubs

--- a/wiremock/referenceDataStubs.ts
+++ b/wiremock/referenceDataStubs.ts
@@ -1,6 +1,7 @@
 import departureReasonsJson from './stubs/departure-reasons.json'
 import moveOnCategoriesJson from './stubs/move-on-categories.json'
 import destinationProvidersJson from './stubs/destination-providers.json'
+import cancellationReasonsJson from './stubs/cancellation-reasons.json'
 
 const departureReasons = {
   request: {
@@ -44,4 +45,18 @@ const destinationProviders = {
   },
 }
 
-export { departureReasons, moveOnCategories, destinationProviders }
+const cancellationReasons = {
+  request: {
+    method: 'GET',
+    url: '/reference-data/cancellation-reasons',
+  },
+  response: {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+    },
+    jsonBody: cancellationReasonsJson,
+  },
+}
+
+export { departureReasons, moveOnCategories, destinationProviders, cancellationReasons }

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -8,6 +8,8 @@ import bookingStubs from './bookingStubs'
 import arrivalStubs from './arrivalStubs'
 import nonArrivalStubs from './nonArrivalStubs'
 import departureStubs from './departuresStubs'
+import cancellationStubs from './cancellationStubs'
+
 import * as referenceDataStubs from './referenceDataStubs'
 
 const stubs = []
@@ -89,6 +91,7 @@ stubs.push(
   ...arrivalStubs,
   ...nonArrivalStubs,
   ...departureStubs,
+  ...cancellationStubs,
   ...Object.values(referenceDataStubs),
 )
 

--- a/wiremock/stubs/cancellation-reasons.json
+++ b/wiremock/stubs/cancellation-reasons.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "78b9c1a4-1d60-11ed-861d-0242ac120002",
+    "name": "Recall"
+  },
+  {
+    "id": "51b44b8c-f7f3-415d-90c3-61bb7fb96286",
+    "name": "Death"
+  },
+  {
+    "id": "9ddc9bfc-72fa-4a25-88c0-cc0ff8c6c00e",
+    "name": "Request from Probabtion Practictioner"
+  },
+  {
+    "id": "7f3eb6cd-b3fc-4a8d-b9ce-5959918ffbe8",
+    "name": "Non-Arrival"
+  }
+]


### PR DESCRIPTION
This adds the required clients and services for us to create and get a cancellation, as well as fetching a list of the required cancellation reasons from the API. Once this is in, we'll be able to build out the requisite controllers and views, as well as integration tests.