### PR TITLE
(550) Show the total number of available beds for a premises in the UI

### DIFF
--- a/integration_tests/pages/premisesShow.ts
+++ b/integration_tests/pages/premisesShow.ts
@@ -30,6 +30,11 @@ export default class PremisesShowPage extends Page {
       .contains('Number of Beds')
       .siblings('.govuk-summary-list__value')
       .should('contain', this.premises.bedCount)
+
+    cy.get('.govuk-summary-list__key')
+      .contains('Available Beds')
+      .siblings('.govuk-summary-list__value')
+      .should('contain', this.premises.availableBedsForToday)
   }
 
   shouldShowBookings(

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -126,6 +126,7 @@ declare module 'approved-premises' {
       postcode: string
       bedCount: number
       apAreaId: string
+      availableBedsForToday: number
     }
     Booking: {
       id: string

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -94,7 +94,13 @@ describe('PremisesService', () => {
 
   describe('getPremisesDetails', () => {
     it('returns a title and a summary list for a given Premises ID', async () => {
-      const premises = premisesFactory.build({ name: 'Test', apCode: 'ABC', postcode: 'SW1A 1AA', bedCount: 50 })
+      const premises = premisesFactory.build({
+        name: 'Test',
+        apCode: 'ABC',
+        postcode: 'SW1A 1AA',
+        bedCount: 50,
+        availableBedsForToday: 20,
+      })
       premisesClient.getPremises.mockResolvedValue(premises)
 
       const result = await service.getPremisesDetails(premises.id)
@@ -114,6 +120,10 @@ describe('PremisesService', () => {
             {
               key: { text: 'Number of Beds' },
               value: { text: '50' },
+            },
+            {
+              key: { text: 'Available Beds' },
+              value: { text: '20' },
             },
           ],
         },

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -68,6 +68,10 @@ export default class PremisesService {
           key: this.textValue('Number of Beds'),
           value: this.textValue(premises.bedCount.toString()),
         },
+        {
+          key: this.textValue('Available Beds'),
+          value: this.textValue(premises.availableBedsForToday.toString()),
+        },
       ],
     }
   }

--- a/server/testutils/factories/premises.ts
+++ b/server/testutils/factories/premises.ts
@@ -9,5 +9,6 @@ export default Factory.define<Premises>(() => ({
   apCode: faker.random.alphaNumeric(5, { casing: 'upper' }),
   postcode: faker.address.zipCode(),
   bedCount: 50,
+  availableBedsForToday: faker.datatype.number({ min: 0, max: 50 }),
   apAreaId: faker.random.alphaNumeric(2, { casing: 'upper' }),
 }))

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -1,8 +1,12 @@
 /* eslint-disable no-console */
+import { DeepPartial } from 'fishery'
+
+import type { Premises } from 'approved-premises'
 import { bulkStub } from './index'
 
-import premises from './stubs/premises.json'
+import premisesJson from './stubs/premises.json'
 import bookingFactory from '../server/testutils/factories/booking'
+import premisesFactory from '../server/testutils/factories/premises'
 
 import bookingStubs from './bookingStubs'
 import arrivalStubs from './arrivalStubs'
@@ -13,6 +17,8 @@ import cancellationStubs from './cancellationStubs'
 import * as referenceDataStubs from './referenceDataStubs'
 
 const stubs = []
+
+const premises = premisesJson.map(item => premisesFactory.build(item as DeepPartial<Premises>))
 
 stubs.push({
   request: {
@@ -28,18 +34,18 @@ stubs.push({
   },
 })
 
-premises.forEach(p => {
+premises.forEach(item => {
   stubs.push({
     request: {
       method: 'GET',
-      url: `/premises/${p.id}`,
+      url: `/premises/${item.id}`,
     },
     response: {
       status: 200,
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      jsonBody: p,
+      jsonBody: item,
     },
   })
 
@@ -58,7 +64,7 @@ premises.forEach(p => {
   stubs.push({
     request: {
       method: 'GET',
-      url: `/premises/${p.id}/bookings`,
+      url: `/premises/${item.id}/bookings`,
     },
     response: {
       status: 200,
@@ -73,7 +79,7 @@ premises.forEach(p => {
     stubs.push({
       request: {
         method: 'GET',
-        url: `/premises/${p.id}/bookings/${booking.id}`,
+        url: `/premises/${item.id}/bookings/${booking.id}`,
       },
       response: {
         status: 200,

--- a/wiremock/stubs/premises.json
+++ b/wiremock/stubs/premises.json
@@ -4,7 +4,7 @@
     "name": "Beckenham Road",
     "apCode": "BELON",
     "postcode": "BR3 4LR",
-    "bedCount": "20",
+    "bedCount": 20,
     "apAreaId": "LON"
   },
   {
@@ -12,7 +12,7 @@
     "name": "Camden House",
     "apCode": "CALON",
     "postcode": "NW1 7HA",
-    "bedCount": "44",
+    "bedCount": 44,
     "apAreaId": "LON"
   },
   {
@@ -20,7 +20,7 @@
     "name": "Canadian Avenue",
     "apCode": "CALON",
     "postcode": "SE6 3AU",
-    "bedCount": "24",
+    "bedCount": 24,
     "apAreaId": "LON"
   },
   {
@@ -28,7 +28,7 @@
     "name": "Ealing",
     "apCode": "EALON",
     "postcode": "W5 2HS",
-    "bedCount": "18",
+    "bedCount": 18,
     "apAreaId": "LON"
   },
   {
@@ -36,7 +36,7 @@
     "name": "Hestia Battersea",
     "apCode": "HELON",
     "postcode": "SW11 2AH",
-    "bedCount": "10",
+    "bedCount": 10,
     "apAreaId": "LON"
   },
   {
@@ -44,7 +44,7 @@
     "name": "Hestia Streatham",
     "apCode": "HELON",
     "postcode": "SW16 2QP",
-    "bedCount": "25",
+    "bedCount": 25,
     "apAreaId": "LON"
   },
   {
@@ -52,7 +52,7 @@
     "name": "Joyce Meggie House",
     "apCode": "JOLON",
     "postcode": "SE5 0BL",
-    "bedCount": "36",
+    "bedCount": 36,
     "apAreaId": "LON"
   },
   {
@@ -60,7 +60,7 @@
     "name": "Katherine Price Hughes House",
     "apCode": "KALON",
     "postcode": "N5 2EA",
-    "bedCount": "20",
+    "bedCount": 20,
     "apAreaId": "LON"
   },
   {
@@ -68,7 +68,7 @@
     "name": "Kew",
     "apCode": "KELON",
     "postcode": "TW9 4HQ",
-    "bedCount": "23",
+    "bedCount": 23,
     "apAreaId": "LON"
   },
   {
@@ -76,7 +76,7 @@
     "name": "Seafield Lodge",
     "apCode": "SELON",
     "postcode": "NW2 3PS",
-    "bedCount": "20",
+    "bedCount": 20,
     "apAreaId": "LON"
   },
   {
@@ -84,7 +84,7 @@
     "name": "Tulse Hill",
     "apCode": "TULON",
     "postcode": "SW2 2QD",
-    "bedCount": "31",
+    "bedCount": 31,
     "apAreaId": "LON"
   },
   {
@@ -92,7 +92,7 @@
     "name": "Westbourne House",
     "apCode": "WELON",
     "postcode": "E7 9HL",
-    "bedCount": "41",
+    "bedCount": 41,
     "apAreaId": "LON"
   },
   {
@@ -100,7 +100,7 @@
     "name": "Astral Grove",
     "apCode": "ASMids",
     "postcode": "NG15 6FY",
-    "bedCount": "14",
+    "bedCount": 14,
     "apAreaId": "Mids"
   },
   {
@@ -108,7 +108,7 @@
     "name": "Augustus House",
     "apCode": "AUMids",
     "postcode": "CV32 6JG",
-    "bedCount": "22",
+    "bedCount": 22,
     "apAreaId": "Mids"
   },
   {
@@ -116,7 +116,7 @@
     "name": "Bilston House",
     "apCode": "BIMids",
     "postcode": "WV14 6AH",
-    "bedCount": "14",
+    "bedCount": 14,
     "apAreaId": "Mids"
   },
   {
@@ -124,7 +124,7 @@
     "name": "Braley House",
     "apCode": "BRMids",
     "postcode": "WR3 7BT",
-    "bedCount": "20",
+    "bedCount": 20,
     "apAreaId": "Mids"
   },
   {
@@ -132,7 +132,7 @@
     "name": "Burdett Lodge",
     "apCode": "BUMids",
     "postcode": "DE22 3BR",
-    "bedCount": "29",
+    "bedCount": 29,
     "apAreaId": "Mids"
   },
   {
@@ -140,7 +140,7 @@
     "name": "Carpenter House",
     "apCode": "CAMids",
     "postcode": "B16 9HS",
-    "bedCount": "21",
+    "bedCount": 21,
     "apAreaId": "Mids"
   },
   {
@@ -148,7 +148,7 @@
     "name": "Crowley House",
     "apCode": "CRMids",
     "postcode": "B29 6QY",
-    "bedCount": "21",
+    "bedCount": 21,
     "apAreaId": "Mids"
   },
   {
@@ -156,7 +156,7 @@
     "name": "Elliott House",
     "apCode": "ELMids",
     "postcode": "B12 9QA",
-    "bedCount": "20",
+    "bedCount": 20,
     "apAreaId": "Mids"
   },
   {
@@ -164,7 +164,7 @@
     "name": "Howard House",
     "apCode": "HOMids",
     "postcode": "LE1 6YF",
-    "bedCount": "13",
+    "bedCount": 13,
     "apAreaId": "Mids"
   },
   {
@@ -172,7 +172,7 @@
     "name": "Jackie Harriet House",
     "apCode": "JAMids",
     "postcode": "B6 6AJ",
-    "bedCount": "20",
+    "bedCount": 20,
     "apAreaId": "Mids"
   },
   {
@@ -180,7 +180,7 @@
     "name": "Kirk Lodge",
     "apCode": "KIMids",
     "postcode": "LE2 2PJ",
-    "bedCount": "32",
+    "bedCount": 32,
     "apAreaId": "Mids"
   },
   {
@@ -188,7 +188,7 @@
     "name": "McIntyre House",
     "apCode": "MCMids",
     "postcode": "CV11 5RD",
-    "bedCount": "19",
+    "bedCount": 19,
     "apAreaId": "Mids"
   },
   {
@@ -196,7 +196,7 @@
     "name": "Southwell House",
     "apCode": "SOMids",
     "postcode": "NG7 4DJ",
-    "bedCount": "21",
+    "bedCount": 21,
     "apAreaId": "Mids"
   },
   {
@@ -204,7 +204,7 @@
     "name": "Staitheford House",
     "apCode": "STMids",
     "postcode": "ST17 4JX",
-    "bedCount": "13",
+    "bedCount": 13,
     "apAreaId": "Mids"
   },
   {
@@ -212,7 +212,7 @@
     "name": "Stonnall Road",
     "apCode": "STMids",
     "postcode": "WS9 8JZ",
-    "bedCount": "11",
+    "bedCount": 11,
     "apAreaId": "Mids"
   },
   {
@@ -220,7 +220,7 @@
     "name": "Sycamore Lodge",
     "apCode": "SYMids",
     "postcode": "B69 4TH",
-    "bedCount": "32",
+    "bedCount": 32,
     "apAreaId": "Mids"
   },
   {
@@ -228,7 +228,7 @@
     "name": "Trent House",
     "apCode": "TRMids",
     "postcode": "NG3 4JF",
-    "bedCount": "20",
+    "bedCount": 20,
     "apAreaId": "Mids"
   },
   {
@@ -236,7 +236,7 @@
     "name": "Wenger House ",
     "apCode": "WEMids",
     "postcode": "ST5 1HJ",
-    "bedCount": "25",
+    "bedCount": 25,
     "apAreaId": "Mids"
   },
   {
@@ -244,7 +244,7 @@
     "name": "Wharflane House",
     "apCode": "WHMids",
     "postcode": "ST1 4PW",
-    "bedCount": "22",
+    "bedCount": 22,
     "apAreaId": "Mids"
   },
   {
@@ -252,7 +252,7 @@
     "name": "Wordsworth House",
     "apCode": "WOMids",
     "postcode": "LN1 3NQ",
-    "bedCount": "20",
+    "bedCount": 20,
     "apAreaId": "Mids"
   },
   {
@@ -260,7 +260,7 @@
     "name": "Albion Street",
     "apCode": "ALNE",
     "postcode": "WF13 2AJ",
-    "bedCount": "24",
+    "bedCount": 24,
     "apAreaId": "NE"
   },
   {
@@ -268,7 +268,7 @@
     "name": "Cardigan House",
     "apCode": "CANE",
     "postcode": "LS6 3BJ",
-    "bedCount": "26",
+    "bedCount": 26,
     "apAreaId": "NE"
   },
   {
@@ -276,7 +276,7 @@
     "name": "Cuthbert House",
     "apCode": "CUNE",
     "postcode": "NE8 2SH",
-    "bedCount": "24",
+    "bedCount": 24,
     "apAreaId": "NE"
   },
   {
@@ -284,7 +284,7 @@
     "name": "Elm Bank",
     "apCode": "ELNE",
     "postcode": "BD19 3LW",
-    "bedCount": "23",
+    "bedCount": 23,
     "apAreaId": "NE"
   },
   {
@@ -292,7 +292,7 @@
     "name": "Holbeck House",
     "apCode": "HONE",
     "postcode": "LS12 1BS",
-    "bedCount": "25",
+    "bedCount": 25,
     "apAreaId": "NE"
   },
   {
@@ -300,7 +300,7 @@
     "name": "Nelson House",
     "apCode": "NENE",
     "postcode": "TS6 6DD",
-    "bedCount": "24",
+    "bedCount": 24,
     "apAreaId": "NE"
   },
   {
@@ -308,7 +308,7 @@
     "name": "Norfork Park",
     "apCode": "NONE",
     "postcode": "S2 2RU",
-    "bedCount": "32",
+    "bedCount": 32,
     "apAreaId": "NE"
   },
   {
@@ -316,7 +316,7 @@
     "name": "Ozanam House",
     "apCode": "OZNE",
     "postcode": "NE4 6XD",
-    "bedCount": "26",
+    "bedCount": 26,
     "apAreaId": "NE"
   },
   {
@@ -324,7 +324,7 @@
     "name": "Pennywell House",
     "apCode": "PENE",
     "postcode": "SR4 8DS",
-    "bedCount": "18",
+    "bedCount": 18,
     "apAreaId": "NE"
   },
   {
@@ -332,7 +332,7 @@
     "name": "Queens Road",
     "apCode": "QUNE",
     "postcode": "HU5 2QW",
-    "bedCount": "19",
+    "bedCount": 19,
     "apAreaId": "NE"
   },
   {
@@ -340,7 +340,7 @@
     "name": "Ripon House",
     "apCode": "RINE",
     "postcode": "LS2 9NZ",
-    "bedCount": "22",
+    "bedCount": 22,
     "apAreaId": "NE"
   },
   {
@@ -348,7 +348,7 @@
     "name": "Rookwood",
     "apCode": "RONE",
     "postcode": "S65 1NN",
-    "bedCount": "25",
+    "bedCount": 25,
     "apAreaId": "NE"
   },
   {
@@ -356,7 +356,7 @@
     "name": "Southview",
     "apCode": "SONE",
     "postcode": "YO26 5RU",
-    "bedCount": "22",
+    "bedCount": 22,
     "apAreaId": "NE"
   },
   {
@@ -364,7 +364,7 @@
     "name": "St Christopher's",
     "apCode": "STNE",
     "postcode": "NE4 6QX",
-    "bedCount": "21",
+    "bedCount": 21,
     "apAreaId": "NE"
   },
   {
@@ -372,7 +372,7 @@
     "name": "St Johns",
     "apCode": "STNE",
     "postcode": "LS6 1AG",
-    "bedCount": "29",
+    "bedCount": 29,
     "apAreaId": "NE"
   },
   {
@@ -380,7 +380,7 @@
     "name": "The Crescent ",
     "apCode": "THNE",
     "postcode": "TS5 6SG",
-    "bedCount": "20",
+    "bedCount": 20,
     "apAreaId": "NE"
   },
   {
@@ -388,7 +388,7 @@
     "name": "Town Moor",
     "apCode": "TONE",
     "postcode": "DN1 2QL",
-    "bedCount": "19",
+    "bedCount": 19,
     "apAreaId": "NE"
   },
   {
@@ -396,7 +396,7 @@
     "name": "Victoria House",
     "apCode": "VINE",
     "postcode": "DN15 6AS",
-    "bedCount": "20",
+    "bedCount": 20,
     "apAreaId": "NE"
   },
   {
@@ -404,7 +404,7 @@
     "name": "Westgate",
     "apCode": "WENE",
     "postcode": "WF2 9RF",
-    "bedCount": "19",
+    "bedCount": 19,
     "apAreaId": "NE"
   },
   {
@@ -412,7 +412,7 @@
     "name": "Adelaide House",
     "apCode": "ADNW",
     "postcode": "L7 2FP",
-    "bedCount": "18",
+    "bedCount": 18,
     "apAreaId": "NW"
   },
   {
@@ -420,7 +420,7 @@
     "name": "Ascot House",
     "apCode": "ASNW",
     "postcode": "SK4 2PB",
-    "bedCount": "25",
+    "bedCount": 25,
     "apAreaId": "NW"
   },
   {
@@ -428,7 +428,7 @@
     "name": "Bowling Green",
     "apCode": "BONW",
     "postcode": "CA3 8DP",
-    "bedCount": "25",
+    "bedCount": 25,
     "apAreaId": "NW"
   },
   {
@@ -436,7 +436,7 @@
     "name": "Bradshaw House",
     "apCode": "BRNW",
     "postcode": "BL9 5DE",
-    "bedCount": "26",
+    "bedCount": 26,
     "apAreaId": "NW"
   },
   {
@@ -444,7 +444,7 @@
     "name": "Bunbury House",
     "apCode": "BUNW",
     "postcode": "CH65 9HE",
-    "bedCount": "23",
+    "bedCount": 23,
     "apAreaId": "NW"
   },
   {
@@ -452,7 +452,7 @@
     "name": "Chorlton",
     "apCode": "CHNW",
     "postcode": "M21 9LH",
-    "bedCount": "27",
+    "bedCount": 27,
     "apAreaId": "NW"
   },
   {
@@ -460,7 +460,7 @@
     "name": "Edith Rigby House",
     "apCode": "EDNW",
     "postcode": "PR1 3JE",
-    "bedCount": "12",
+    "bedCount": 12,
     "apAreaId": "NW"
   },
   {
@@ -468,7 +468,7 @@
     "name": "Haworth House",
     "apCode": "HANW",
     "postcode": "BB2 2HL",
-    "bedCount": "26",
+    "bedCount": 26,
     "apAreaId": "NW"
   },
   {
@@ -476,7 +476,7 @@
     "name": "Highfield House",
     "apCode": "HINW",
     "postcode": "BB5 0PX",
-    "bedCount": "22",
+    "bedCount": 22,
     "apAreaId": "NW"
   },
   {
@@ -484,7 +484,7 @@
     "name": "Linden Bank",
     "apCode": "LINW",
     "postcode": "CW11 3BD",
-    "bedCount": "22",
+    "bedCount": 22,
     "apAreaId": "NW"
   },
   {
@@ -492,7 +492,7 @@
     "name": "Merseybank",
     "apCode": "MENW",
     "postcode": "L3 7HS",
-    "bedCount": "24",
+    "bedCount": 24,
     "apAreaId": "NW"
   },
   {
@@ -500,7 +500,7 @@
     "name": "Southwood",
     "apCode": "SONW",
     "postcode": "L17 7BQ",
-    "bedCount": "29",
+    "bedCount": 29,
     "apAreaId": "NW"
   },
   {
@@ -508,7 +508,7 @@
     "name": "St Josephs",
     "apCode": "STNW",
     "postcode": "M30 8PF",
-    "bedCount": "29",
+    "bedCount": 29,
     "apAreaId": "NW"
   },
   {
@@ -516,7 +516,7 @@
     "name": "Stafford House",
     "apCode": "STNW",
     "postcode": "L8 3SG",
-    "bedCount": "16",
+    "bedCount": 16,
     "apAreaId": "NW"
   },
   {
@@ -524,7 +524,7 @@
     "name": "Wilton Place",
     "apCode": "WINW",
     "postcode": "OL9 7QW",
-    "bedCount": "29",
+    "bedCount": 29,
     "apAreaId": "NW"
   },
   {
@@ -532,7 +532,7 @@
     "name": "Withington Road",
     "apCode": "WINW",
     "postcode": "M16 8JN",
-    "bedCount": "35",
+    "bedCount": 35,
     "apAreaId": "NW"
   },
   {
@@ -540,7 +540,7 @@
     "name": "Bedford",
     "apCode": "BESEE",
     "postcode": "MK40 2AP",
-    "bedCount": "17",
+    "bedCount": 17,
     "apAreaId": "SEE"
   },
   {
@@ -548,7 +548,7 @@
     "name": "Bridgewood",
     "apCode": "BRSEE",
     "postcode": "NN3 8AX",
-    "bedCount": "22",
+    "bedCount": 22,
     "apAreaId": "SEE"
   },
   {
@@ -556,7 +556,7 @@
     "name": "Brighton",
     "apCode": "BRSEE",
     "postcode": "BN2 1EJ",
-    "bedCount": "16",
+    "bedCount": 16,
     "apAreaId": "SEE"
   },
   {
@@ -564,7 +564,7 @@
     "name": "Felmores",
     "apCode": "FESEE",
     "postcode": "SS13 1RN",
-    "bedCount": "25",
+    "bedCount": 25,
     "apAreaId": "SEE"
   },
   {
@@ -572,7 +572,7 @@
     "name": "Fleming House",
     "apCode": "FLSEE",
     "postcode": "ME16 8SH",
-    "bedCount": "31",
+    "bedCount": 31,
     "apAreaId": "SEE"
   },
   {
@@ -580,7 +580,7 @@
     "name": "John Boag House",
     "apCode": "JOSEE",
     "postcode": "NR3 2DF",
-    "bedCount": "25",
+    "bedCount": 25,
     "apAreaId": "SEE"
   },
   {
@@ -588,7 +588,7 @@
     "name": "Lightfoot House",
     "apCode": "LISEE",
     "postcode": "IP4 5AA",
-    "bedCount": "26",
+    "bedCount": 26,
     "apAreaId": "SEE"
   },
   {
@@ -596,7 +596,7 @@
     "name": "Luton",
     "apCode": "LUSEE",
     "postcode": "LU1 1RG",
-    "bedCount": "20",
+    "bedCount": 20,
     "apAreaId": "SEE"
   },
   {
@@ -604,7 +604,7 @@
     "name": "Peterborough",
     "apCode": "PESEE",
     "postcode": "PE1 3RW",
-    "bedCount": "31",
+    "bedCount": 31,
     "apAreaId": "SEE"
   },
   {
@@ -612,7 +612,7 @@
     "name": "St Catherines Priory ",
     "apCode": "STSEE",
     "postcode": "GU2 4EE",
-    "bedCount": "19",
+    "bedCount": 19,
     "apAreaId": "SEE"
   },
   {
@@ -620,7 +620,7 @@
     "name": "The Cottage",
     "apCode": "THSEE",
     "postcode": "IP1 6LH",
-    "bedCount": "14",
+    "bedCount": 14,
     "apAreaId": "SEE"
   },
   {
@@ -628,7 +628,7 @@
     "name": "Abingdon Road",
     "apCode": "ABSWSC",
     "postcode": "OX1 4PY",
-    "bedCount": "20",
+    "bedCount": 20,
     "apAreaId": "SWSC"
   },
   {
@@ -636,7 +636,7 @@
     "name": "Ashley House",
     "apCode": "ASSWSC",
     "postcode": "BS2 8NB",
-    "bedCount": "22",
+    "bedCount": 22,
     "apAreaId": "SWSC"
   },
   {
@@ -644,7 +644,7 @@
     "name": "Bridge House",
     "apCode": "BRSWSC",
     "postcode": "BS7 0PD",
-    "bedCount": "14",
+    "bedCount": 14,
     "apAreaId": "SWSC"
   },
   {
@@ -652,7 +652,7 @@
     "name": "Brigstocke Road",
     "apCode": "BRSWSC",
     "postcode": "BS2 8UB",
-    "bedCount": "25",
+    "bedCount": 25,
     "apAreaId": "SWSC"
   },
   {
@@ -660,7 +660,7 @@
     "name": "Clarks House",
     "apCode": "CLSWSC",
     "postcode": "OX1 1RE",
-    "bedCount": "18",
+    "bedCount": 18,
     "apAreaId": "SWSC"
   },
   {
@@ -668,7 +668,7 @@
     "name": "Dickson House",
     "apCode": "DISWSC",
     "postcode": "PO16 7SL",
-    "bedCount": "19",
+    "bedCount": 19,
     "apAreaId": "SWSC"
   },
   {
@@ -676,7 +676,7 @@
     "name": "Eden House",
     "apCode": "EDSWSC",
     "postcode": "BS16 2EQ",
-    "bedCount": "26",
+    "bedCount": 26,
     "apAreaId": "SWSC"
   },
   {
@@ -684,7 +684,7 @@
     "name": "Elizabeth Fry",
     "apCode": "ELSWSC",
     "postcode": "RG1 6LQ",
-    "bedCount": "24",
+    "bedCount": 24,
     "apAreaId": "SWSC"
   },
   {
@@ -692,7 +692,7 @@
     "name": "Glogan House",
     "apCode": "GLSWSC",
     "postcode": "TA6 3LP",
-    "bedCount": "16",
+    "bedCount": 16,
     "apAreaId": "SWSC"
   },
   {
@@ -700,7 +700,7 @@
     "name": "Great Holm",
     "apCode": "GRSWSC",
     "postcode": "MK8 9AL",
-    "bedCount": "16",
+    "bedCount": 16,
     "apAreaId": "SWSC"
   },
   {
@@ -708,7 +708,7 @@
     "name": "Landguard Road",
     "apCode": "LASWSC",
     "postcode": "SO15 5DJ",
-    "bedCount": "26",
+    "bedCount": 26,
     "apAreaId": "SWSC"
   },
   {
@@ -716,7 +716,7 @@
     "name": "Lawson House",
     "apCode": "LASWSC",
     "postcode": "PL1 5QU",
-    "bedCount": "19",
+    "bedCount": 19,
     "apAreaId": "SWSC"
   },
   {
@@ -724,7 +724,7 @@
     "name": "Manor Lodge",
     "apCode": "MASWSC",
     "postcode": "SL4 2RL",
-    "bedCount": "25",
+    "bedCount": 25,
     "apAreaId": "SWSC"
   },
   {
@@ -732,7 +732,7 @@
     "name": "Meneghy House",
     "apCode": "MESWSC",
     "postcode": "TR14 8NQ",
-    "bedCount": "18",
+    "bedCount": 18,
     "apAreaId": "SWSC"
   },
   {
@@ -740,7 +740,7 @@
     "name": "Ryecroft",
     "apCode": "RYSWSC",
     "postcode": "GL1 4LY",
-    "bedCount": "18",
+    "bedCount": 18,
     "apAreaId": "SWSC"
   },
   {
@@ -748,7 +748,7 @@
     "name": "St Leonards",
     "apCode": "STSWSC",
     "postcode": "RG30 2AA",
-    "bedCount": "22",
+    "bedCount": 22,
     "apAreaId": "SWSC"
   },
   {
@@ -756,7 +756,7 @@
     "name": "The Grange",
     "apCode": "THSWSC",
     "postcode": "PO7 5PL",
-    "bedCount": "25",
+    "bedCount": 25,
     "apAreaId": "SWSC"
   },
   {
@@ -764,7 +764,7 @@
     "name": "The Pines",
     "apCode": "THSWSC",
     "postcode": "BH5 1DU",
-    "bedCount": "16",
+    "bedCount": 16,
     "apAreaId": "SWSC"
   },
   {
@@ -772,7 +772,7 @@
     "name": "Weston",
     "apCode": "WESWSC",
     "postcode": "DT4 8SU",
-    "bedCount": "25",
+    "bedCount": 25,
     "apAreaId": "SWSC"
   },
   {
@@ -780,7 +780,7 @@
     "name": "Mandeville House",
     "apCode": "MAWales",
     "postcode": "CF11 6JY",
-    "bedCount": "26",
+    "bedCount": 26,
     "apAreaId": "Wales"
   },
   {
@@ -788,7 +788,7 @@
     "name": "Plas y Wern",
     "apCode": "PLWales",
     "postcode": "LL14 6RN",
-    "bedCount": "27",
+    "bedCount": 27,
     "apAreaId": "Wales"
   },
   {
@@ -796,7 +796,7 @@
     "name": "Quay House",
     "apCode": "QUWales",
     "postcode": "SA1 2AW",
-    "bedCount": "27",
+    "bedCount": 27,
     "apAreaId": "Wales"
   },
   {
@@ -804,7 +804,7 @@
     "name": "Ty Newydd",
     "apCode": "TYWales",
     "postcode": "LL57 4HP",
-    "bedCount": "23",
+    "bedCount": 23,
     "apAreaId": "Wales"
   }
 ]


### PR DESCRIPTION
A premises now has an `availableBedsForToday` attribute. This PR updates the Premises type to add this attribute, and displays it on the premises view page.

![image](https://user-images.githubusercontent.com/109774/185140039-36f5bc77-3aa0-43a3-b8cd-dc41c4c8ea5f.png)
