### PR TITLE
(614) Smarten up our token sharing

### DIFF
--- a/server/controllers/arrivalsController.test.ts
+++ b/server/controllers/arrivalsController.test.ts
@@ -5,6 +5,7 @@ import type { ErrorsAndUserInput } from 'approved-premises'
 import ArrivalService from '../services/arrivalService'
 import ArrivalsController from './arrivalsController'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../utils/validation'
+import servicesShouldGetTokenFromRequest from './shared_examples'
 
 jest.mock('../utils/validation')
 
@@ -13,13 +14,8 @@ describe('ArrivalsController', () => {
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
-  let arrivalsController: ArrivalsController
-  let arrivalService: DeepMocked<ArrivalService>
-
-  beforeEach(() => {
-    arrivalService = createMock<ArrivalService>({})
-    arrivalsController = new ArrivalsController(arrivalService)
-  })
+  const arrivalService = createMock<ArrivalService>({})
+  const arrivalsController = new ArrivalsController(arrivalService)
 
   describe('new', () => {
     it('renders the form', () => {
@@ -66,6 +62,8 @@ describe('ArrivalsController', () => {
   })
 
   describe('create', () => {
+    servicesShouldGetTokenFromRequest([arrivalService], request)
+
     it('creates an arrival and redirects to the premises page', async () => {
       const requestHandler = arrivalsController.create()
 

--- a/server/controllers/arrivalsController.ts
+++ b/server/controllers/arrivalsController.ts
@@ -32,7 +32,7 @@ export default class ArrivalsController {
       }
 
       try {
-        await this.arrivalService.createArrival(premisesId, bookingId, arrival)
+        await this.arrivalService.withTokenFromRequest(req).createArrival(premisesId, bookingId, arrival)
 
         res.redirect(`/premises/${premisesId}`)
       } catch (err) {

--- a/server/controllers/bookingsController.test.ts
+++ b/server/controllers/bookingsController.test.ts
@@ -7,6 +7,7 @@ import BookingsController from './bookingsController'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../utils/validation'
 
 import bookingFactory from '../testutils/factories/booking'
+import servicesShouldGetTokenFromRequest from './shared_examples'
 
 jest.mock('../utils/validation')
 
@@ -15,17 +16,12 @@ describe('bookingsController', () => {
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
-  let bookingController: BookingsController
-  let bookingService: DeepMocked<BookingService>
-
-  beforeEach(() => {
-    jest.resetAllMocks()
-
-    bookingService = createMock<BookingService>({})
-    bookingController = new BookingsController(bookingService)
-  })
+  const bookingService = createMock<BookingService>({})
+  const bookingController = new BookingsController(bookingService)
 
   describe('show', () => {
+    servicesShouldGetTokenFromRequest([bookingService], request)
+
     it('should fetch the booking and render the show page', async () => {
       const booking = bookingFactory.build()
       bookingService.getBooking.mockResolvedValue(booking)
@@ -82,6 +78,8 @@ describe('bookingsController', () => {
   })
 
   describe('create', () => {
+    servicesShouldGetTokenFromRequest([bookingService], request)
+
     it('given the expected form data, the posting of the booking is successful should redirect to the "premises" page', async () => {
       const booking = bookingFactory.build()
       bookingService.postBooking.mockResolvedValue(booking)
@@ -143,6 +141,8 @@ describe('bookingsController', () => {
   })
 
   describe('confirm', () => {
+    servicesShouldGetTokenFromRequest([bookingService], request)
+
     it('renders the form with the details from the booking that is requested', async () => {
       const booking = bookingFactory.build({
         arrivalDate: new Date('07/27/22').toISOString(),

--- a/server/controllers/bookingsController.ts
+++ b/server/controllers/bookingsController.ts
@@ -12,7 +12,7 @@ export default class BookingsController {
     return async (req: Request, res: Response) => {
       const { premisesId, bookingId } = req.params
 
-      const booking = await this.bookingService.getBooking(premisesId, bookingId)
+      const booking = await this.bookingService.withTokenFromRequest(req).getBooking(premisesId, bookingId)
 
       return res.render(`bookings/show`, { booking, premisesId })
     }
@@ -38,7 +38,9 @@ export default class BookingsController {
       }
 
       try {
-        const confirmedBooking = await this.bookingService.postBooking(premisesId as string, booking)
+        const confirmedBooking = await this.bookingService
+          .withTokenFromRequest(req)
+          .postBooking(premisesId as string, booking)
 
         res.redirect(`/premises/${premisesId}/bookings/${confirmedBooking.id}/confirmation`)
       } catch (err) {
@@ -50,7 +52,7 @@ export default class BookingsController {
   confirm(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, bookingId } = req.params
-      const booking = await this.bookingService.getBooking(premisesId, bookingId)
+      const booking = await this.bookingService.withTokenFromRequest(req).getBooking(premisesId, bookingId)
 
       return res.render('bookings/confirm', booking)
     }

--- a/server/controllers/cancellationsController.test.ts
+++ b/server/controllers/cancellationsController.test.ts
@@ -11,6 +11,7 @@ import { fetchErrorsAndUserInput, catchValidationErrorOrPropogate } from '../uti
 import bookingFactory from '../testutils/factories/booking'
 import cancellationFactory from '../testutils/factories/cancellation'
 import referenceDataFactory from '../testutils/factories/referenceData'
+import servicesShouldGetTokenFromRequest from './shared_examples'
 
 jest.mock('../utils/validation')
 
@@ -19,29 +20,25 @@ describe('cancellationsController', () => {
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
-  let cancellationsController: CancellationsController
-
-  let cancellationService: DeepMocked<CancellationService>
-  let bookingService: DeepMocked<BookingService>
-
   const premisesId = 'premisesId'
   const bookingId = 'bookingId'
+
   const booking = bookingFactory.build()
   const cancellationReasons = referenceDataFactory.buildList(4)
 
+  const cancellationService = createMock<CancellationService>({})
+  const bookingService = createMock<BookingService>({})
+
+  const cancellationsController = new CancellationsController(cancellationService, bookingService)
+
   beforeEach(() => {
-    jest.resetAllMocks()
-
-    cancellationService = createMock<CancellationService>({})
-    bookingService = createMock<BookingService>({})
-
-    cancellationsController = new CancellationsController(cancellationService, bookingService)
-
     bookingService.getBooking.mockResolvedValue(booking)
     cancellationService.getCancellationReasons.mockResolvedValue(cancellationReasons)
   })
 
   describe('new', () => {
+    servicesShouldGetTokenFromRequest([cancellationService, bookingService], request)
+
     it('should render the form', async () => {
       ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
         return { errors: {}, errorSummary: [], userInput: {} }
@@ -83,6 +80,8 @@ describe('cancellationsController', () => {
   })
 
   describe('create', () => {
+    servicesShouldGetTokenFromRequest([cancellationService], request)
+
     it('creates a Cancellation and redirects to the confirmation page', async () => {
       const cancellation = cancellationFactory.build()
 
@@ -149,6 +148,8 @@ describe('cancellationsController', () => {
   })
 
   describe('confirm', () => {
+    servicesShouldGetTokenFromRequest([cancellationService, bookingService], request)
+
     it('renders the confirmation page with the details from the cancellation that is requested', async () => {
       const cancellation = cancellationFactory.build()
 

--- a/server/controllers/cancellationsController.ts
+++ b/server/controllers/cancellationsController.ts
@@ -17,8 +17,8 @@ export default class CancellationsController {
       const { premisesId, bookingId } = req.params
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
-      const booking = await this.bookingService.getBooking(premisesId, bookingId)
-      const cancellationReasons = await this.cancellationService.getCancellationReasons()
+      const booking = await this.bookingService.withTokenFromRequest(req).getBooking(premisesId, bookingId)
+      const cancellationReasons = await this.cancellationService.withTokenFromRequest(req).getCancellationReasons()
 
       res.render('cancellations/new', {
         premisesId,
@@ -43,7 +43,9 @@ export default class CancellationsController {
       } as CancellationDto
 
       try {
-        const { id } = await this.cancellationService.createCancellation(premisesId, bookingId, cancellation)
+        const { id } = await this.cancellationService
+          .withTokenFromRequest(req)
+          .createCancellation(premisesId, bookingId, cancellation)
         res.redirect(`/premises/${premisesId}/bookings/${bookingId}/cancellations/${id}/confirmation`)
       } catch (err) {
         catchValidationErrorOrPropogate(
@@ -59,8 +61,10 @@ export default class CancellationsController {
   confirm(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, bookingId, id } = req.params
-      const booking = await this.bookingService.getBooking(premisesId, bookingId)
-      const cancellation = await this.cancellationService.getCancellation(premisesId, bookingId, id)
+      const booking = await this.bookingService.withTokenFromRequest(req).getBooking(premisesId, bookingId)
+      const cancellation = await this.cancellationService
+        .withTokenFromRequest(req)
+        .getCancellation(premisesId, bookingId, id)
 
       return res.render('cancellations/confirm', { cancellation, booking })
     }

--- a/server/controllers/departuresController.ts
+++ b/server/controllers/departuresController.ts
@@ -19,9 +19,9 @@ export default class DeparturesController {
       const { premisesId, bookingId } = req.params
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
-      const booking = await this.bookingService.getBooking(premisesId, bookingId)
-      const premisesSelectList = await this.premisesService.getPremisesSelectList()
-      const referenceData = await this.departureService.getReferenceData()
+      const booking = await this.bookingService.withTokenFromRequest(req).getBooking(premisesId, bookingId)
+      const premisesSelectList = await this.premisesService.withTokenFromRequest(req).getPremisesSelectList()
+      const referenceData = await this.departureService.withTokenFromRequest(req).getReferenceData()
 
       res.render('departures/new', {
         premisesId,
@@ -46,7 +46,9 @@ export default class DeparturesController {
       } as DepartureDto
 
       try {
-        const { id } = await this.departureService.createDeparture(premisesId, bookingId, departure)
+        const { id } = await this.departureService
+          .withTokenFromRequest(req)
+          .createDeparture(premisesId, bookingId, departure)
         res.redirect(`/premises/${premisesId}/bookings/${bookingId}/departures/${id}/confirmation`)
       } catch (err) {
         catchValidationErrorOrPropogate(req, res, err, `/premises/${premisesId}/bookings/${bookingId}/departures/new`)
@@ -58,8 +60,10 @@ export default class DeparturesController {
     return async (req: Request, res: Response) => {
       const { premisesId, bookingId, departureId } = req.params
 
-      const booking = await this.bookingService.getBooking(premisesId, bookingId)
-      const departure = await this.departureService.getDeparture(premisesId, bookingId, departureId)
+      const booking = await this.bookingService.withTokenFromRequest(req).getBooking(premisesId, bookingId)
+      const departure = await this.departureService
+        .withTokenFromRequest(req)
+        .getDeparture(premisesId, bookingId, departureId)
 
       return res.render(`departures/confirm`, {
         ...departure,

--- a/server/controllers/nonArrivalsController.test.ts
+++ b/server/controllers/nonArrivalsController.test.ts
@@ -4,6 +4,7 @@ import NonArrivalService from '../services/nonArrivalService'
 
 import NonArrivalsController from './nonArrivalsController'
 import { catchValidationErrorOrPropogate } from '../utils/validation'
+import servicesShouldGetTokenFromRequest from './shared_examples'
 
 jest.mock('../utils/validation')
 
@@ -12,13 +13,10 @@ describe('NonArrivalsController', () => {
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
-  let nonArrivalsController: NonArrivalsController
-  let nonArrivalService: DeepMocked<NonArrivalService>
+  const nonArrivalService = createMock<NonArrivalService>({})
+  const nonArrivalsController = new NonArrivalsController(nonArrivalService)
 
-  beforeEach(() => {
-    nonArrivalService = createMock<NonArrivalService>({})
-    nonArrivalsController = new NonArrivalsController(nonArrivalService)
-  })
+  servicesShouldGetTokenFromRequest([nonArrivalService], request)
 
   describe('create', () => {
     it('creates an nonArrival and redirects to the premises page', async () => {

--- a/server/controllers/nonArrivalsController.ts
+++ b/server/controllers/nonArrivalsController.ts
@@ -19,7 +19,7 @@ export default class NonArrivalsController {
       }
 
       try {
-        await this.nonArrivalService.createNonArrival(premisesId, bookingId, nonArrival)
+        await this.nonArrivalService.withTokenFromRequest(req).createNonArrival(premisesId, bookingId, nonArrival)
 
         res.redirect(`/premises/${premisesId}`)
       } catch (err) {

--- a/server/controllers/premisesController.test.ts
+++ b/server/controllers/premisesController.test.ts
@@ -5,23 +5,20 @@ import type { SummaryListItem, GroupedListofBookings, TableRow } from 'approved-
 import PremisesService from '../services/premisesService'
 import BookingService from '../services/bookingService'
 import PremisesController from './premisesController'
+import servicesShouldGetTokenFromRequest from './shared_examples'
 
 describe('PremisesController', () => {
   const request: DeepMocked<Request> = createMock<Request>({})
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
-  let premisesController: PremisesController
-  let premisesService: DeepMocked<PremisesService>
-  let bookingService: DeepMocked<BookingService>
-
-  beforeEach(() => {
-    premisesService = createMock<PremisesService>({})
-    bookingService = createMock<BookingService>({})
-    premisesController = new PremisesController(premisesService, bookingService)
-  })
+  const premisesService = createMock<PremisesService>({})
+  const bookingService = createMock<BookingService>({})
+  const premisesController = new PremisesController(premisesService, bookingService)
 
   describe('index', () => {
+    servicesShouldGetTokenFromRequest([premisesService], request)
+
     it('should return the table rows to the template', async () => {
       premisesService.tableRows.mockResolvedValue([])
 
@@ -33,6 +30,8 @@ describe('PremisesController', () => {
   })
 
   describe('show', () => {
+    servicesShouldGetTokenFromRequest([premisesService, bookingService], request)
+
     it('should return the premises detail to the template', async () => {
       const premises = { name: 'Some premises', summaryList: { rows: [] as Array<SummaryListItem> } }
       const bookings = createMock<GroupedListofBookings>()

--- a/server/controllers/premisesController.ts
+++ b/server/controllers/premisesController.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, RequestHandler, ShowRequest, ShowRequestHandler } from 'express'
+import type { Request, Response, RequestHandler } from 'express'
 
 import PremisesService from '../services/premisesService'
 import BookingService from '../services/bookingService'
@@ -7,17 +7,20 @@ export default class PremisesController {
   constructor(private readonly premisesService: PremisesService, private readonly bookingService: BookingService) {}
 
   index(): RequestHandler {
-    return async (_req: Request, res: Response) => {
-      const tableRows = await this.premisesService.tableRows()
+    return async (req: Request, res: Response) => {
+      const tableRows = await this.premisesService.withTokenFromRequest(req).tableRows()
       return res.render('premises/index', { tableRows })
     }
   }
 
-  show(): ShowRequestHandler {
-    return async (req: ShowRequest, res: Response) => {
-      const premises = await this.premisesService.getPremisesDetails(req.params.id)
-      const bookings = await this.bookingService.groupedListOfBookingsForPremisesId(req.params.id)
-      const currentResidents = await this.bookingService.currentResidents(req.params.id)
+  show(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const premises = await this.premisesService.withTokenFromRequest(req).getPremisesDetails(req.params.id)
+
+      const bookingService = this.bookingService.withTokenFromRequest(req)
+      const bookings = await bookingService.groupedListOfBookingsForPremisesId(req.params.id)
+      const currentResidents = await bookingService.currentResidents(req.params.id)
+
       return res.render('premises/show', { premises, bookings, currentResidents })
     }
   }

--- a/server/controllers/shared_examples/index.ts
+++ b/server/controllers/shared_examples/index.ts
@@ -1,0 +1,14 @@
+import type { Request } from 'express'
+import type { DeepMocked } from '@golevelup/ts-jest'
+
+import type Service from '../../services/service'
+
+export default function servicesShouldGetTokenFromRequest(services: Array<DeepMocked<Service>>, request: Request) {
+  beforeEach(() => {
+    services.forEach(service => service.withTokenFromRequest.mockReturnValue(service))
+  })
+
+  afterEach(() => {
+    services.forEach(service => expect(service.withTokenFromRequest).toHaveBeenCalledWith(request))
+  })
+}

--- a/server/services/arrivalService.test.ts
+++ b/server/services/arrivalService.test.ts
@@ -3,20 +3,22 @@ import type { Arrival } from 'approved-premises'
 import ArrivalService from './arrivalService'
 import ArrivalClient from '../data/arrivalClient'
 import ArrivalFactory from '../testutils/factories/arrival'
+import itGetsATokenFromARequest from './shared_examples'
 
 jest.mock('../data/arrivalClient.ts')
 
 describe('ArrivalService', () => {
   const arrivalClient = new ArrivalClient(null) as jest.Mocked<ArrivalClient>
-  let service: ArrivalService
-
   const arrivalClientFactory = jest.fn()
+
+  const service = new ArrivalService(arrivalClientFactory)
 
   beforeEach(() => {
     jest.resetAllMocks()
     arrivalClientFactory.mockReturnValue(arrivalClient)
-    service = new ArrivalService(arrivalClientFactory)
   })
+
+  itGetsATokenFromARequest(service)
 
   describe('createArrival', () => {
     it('on success returns the arrival that has been posted', async () => {

--- a/server/services/arrivalService.ts
+++ b/server/services/arrivalService.ts
@@ -1,12 +1,11 @@
 import type { Arrival } from 'approved-premises'
 import type { RestClientBuilder, ArrivalClient } from '../data'
+import Service from './service'
 
-export default class ArrivalService {
-  // TODO: We need to do some more work on authentication to work
-  // out how to get this token, so let's stub for now
-  token = 'FAKE_TOKEN'
-
-  constructor(private readonly arrivalClientFactory: RestClientBuilder<ArrivalClient>) {}
+export default class ArrivalService extends Service {
+  constructor(private readonly arrivalClientFactory: RestClientBuilder<ArrivalClient>) {
+    super()
+  }
 
   async createArrival(
     premisesId: string,

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -4,20 +4,22 @@ import BookingClient from '../data/bookingClient'
 import bookingDtoFactory from '../testutils/factories/bookingDto'
 import bookingFactory from '../testutils/factories/booking'
 import { formatDate } from '../utils/utils'
+import itGetsATokenFromARequest from './shared_examples'
 
 jest.mock('../data/bookingClient.ts')
 
 describe('BookingService', () => {
   const bookingClient = new BookingClient(null) as jest.Mocked<BookingClient>
-  let service: BookingService
 
   const bookingClientFactory = jest.fn()
+  const service = new BookingService(bookingClientFactory)
 
   beforeEach(() => {
     jest.resetAllMocks()
     bookingClientFactory.mockReturnValue(bookingClient)
-    service = new BookingService(bookingClientFactory)
   })
+
+  itGetsATokenFromARequest(service)
 
   describe('postBooking', () => {
     it('on success returns the booking that has been posted', async () => {

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -5,17 +5,17 @@ import type { Booking, BookingDto, TableRow, GroupedListofBookings } from 'appro
 import type { RestClientBuilder } from '../data'
 import BookingClient from '../data/bookingClient'
 import { convertDateString, formatDate } from '../utils/utils'
+import Service from './service'
 
-export default class BookingService {
+export default class BookingService extends Service {
   UPCOMING_WINDOW_IN_DAYS = 5
 
-  constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
+  constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {
+    super()
+  }
 
   async postBooking(premisesId: string, booking: BookingDto): Promise<Booking> {
-    // TODO: We need to do some more work on authentication to work
-    // out how to get this token, so let's stub for now
-    const token = 'FAKE_TOKEN'
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(this.token)
 
     const confirmedBooking = await bookingClient.postBooking(premisesId, booking)
 
@@ -23,10 +23,7 @@ export default class BookingService {
   }
 
   async getBooking(premisesId: string, bookingId: string): Promise<Booking> {
-    // TODO: We need to do some more work on authentication to work
-    // out how to get this token, so let's stub for now
-    const token = 'FAKE_TOKEN'
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(this.token)
 
     const booking = await bookingClient.getBooking(premisesId, bookingId)
 
@@ -34,8 +31,7 @@ export default class BookingService {
   }
 
   async listOfBookingsForPremisesId(premisesId: string): Promise<Array<TableRow>> {
-    const token = 'FAKE_TOKEN'
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(this.token)
 
     const bookings = await bookingClient.allBookingsForPremisesId(premisesId)
 
@@ -43,8 +39,7 @@ export default class BookingService {
   }
 
   async groupedListOfBookingsForPremisesId(premisesId: string): Promise<GroupedListofBookings> {
-    const token = 'FAKE_TOKEN'
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(this.token)
 
     const bookings = await bookingClient.allBookingsForPremisesId(premisesId)
     const today = new Date(new Date().setHours(0, 0, 0, 0))
@@ -77,8 +72,7 @@ export default class BookingService {
   }
 
   async currentResidents(premisesId: string): Promise<Array<TableRow>> {
-    const token = 'FAKE_TOKEN'
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(this.token)
 
     const bookings = await bookingClient.allBookingsForPremisesId(premisesId)
     const arrivedBookings = this.arrivedBookings(bookings)

--- a/server/services/cancellationService.test.ts
+++ b/server/services/cancellationService.test.ts
@@ -5,6 +5,7 @@ import ReferenceDataClient from '../data/referenceDataClient'
 import cancellationDtoFactory from '../testutils/factories/cancellationDto'
 import cancellationFactory from '../testutils/factories/cancellation'
 import referenceDataFactory from '../testutils/factories/referenceData'
+import itGetsATokenFromARequest from './shared_examples'
 
 jest.mock('../data/cancellationClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -12,17 +13,19 @@ jest.mock('../data/referenceDataClient.ts')
 describe('DepartureService', () => {
   const cancellationClient = new CancellationClient(null) as jest.Mocked<CancellationClient>
   const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
-  let service: CancellationService
 
   const CancellationClientFactory = jest.fn()
   const ReferenceDataClientFactory = jest.fn()
+
+  const service = new CancellationService(CancellationClientFactory, ReferenceDataClientFactory)
 
   beforeEach(() => {
     jest.resetAllMocks()
     CancellationClientFactory.mockReturnValue(cancellationClient)
     ReferenceDataClientFactory.mockReturnValue(referenceDataClient)
-    service = new CancellationService(CancellationClientFactory, ReferenceDataClientFactory)
   })
+
+  itGetsATokenFromARequest(service)
 
   describe('createCancellation', () => {
     it('on success returns the cancellation that has been posted', async () => {

--- a/server/services/cancellationService.ts
+++ b/server/services/cancellationService.ts
@@ -1,15 +1,14 @@
 import type { Cancellation, CancellationDto, ReferenceData } from 'approved-premises'
 import type { RestClientBuilder, CancellationClient, ReferenceDataClient } from '../data'
+import Service from './service'
 
-export default class CancellationService {
-  // TODO: We need to do some more work on authentication to work
-  // out how to get this token, so let's stub for now
-  token = 'FAKE_TOKEN'
-
+export default class CancellationService extends Service {
   constructor(
     private readonly cancellationClientFactory: RestClientBuilder<CancellationClient>,
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
-  ) {}
+  ) {
+    super()
+  }
 
   async createCancellation(
     premisesId: string,

--- a/server/services/departureService.test.ts
+++ b/server/services/departureService.test.ts
@@ -8,6 +8,7 @@ import ReferenceDataClient from '../data/referenceDataClient'
 import departureFactory from '../testutils/factories/departure'
 import referenceDataFactory from '../testutils/factories/referenceData'
 import departureDtoFactory from '../testutils/factories/departureDto'
+import itGetsATokenFromARequest from './shared_examples'
 
 jest.mock('../data/departureClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -15,17 +16,18 @@ jest.mock('../data/referenceDataClient.ts')
 describe('DepartureService', () => {
   const departureClient = new DepartureClient(null) as jest.Mocked<DepartureClient>
   const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
-  let service: DepartureService
 
   const DepartureClientFactory = jest.fn()
   const ReferenceDataClientFactory = jest.fn()
+  const service = new DepartureService(DepartureClientFactory, ReferenceDataClientFactory)
 
   beforeEach(() => {
     jest.resetAllMocks()
     DepartureClientFactory.mockReturnValue(departureClient)
     ReferenceDataClientFactory.mockReturnValue(referenceDataClient)
-    service = new DepartureService(DepartureClientFactory, ReferenceDataClientFactory)
   })
+
+  itGetsATokenFromARequest(service)
 
   describe('createDeparture', () => {
     it('on success returns the departure that has been posted', async () => {

--- a/server/services/departureService.ts
+++ b/server/services/departureService.ts
@@ -2,6 +2,7 @@ import { parseISO } from 'date-fns'
 
 import type { Departure, ReferenceData, DepartureDto } from 'approved-premises'
 import type { RestClientBuilder, DepartureClient, ReferenceDataClient } from '../data'
+import Service from './service'
 
 export type DepartureReferenceData = {
   departureReasons: Array<ReferenceData>
@@ -9,15 +10,13 @@ export type DepartureReferenceData = {
   destinationProviders: Array<ReferenceData>
 }
 
-export default class DepartureService {
-  // TODO: We need to do some more work on authentication to work
-  // out how to get this token, so let's stub for now
-  token = 'FAKE_TOKEN'
-
+export default class DepartureService extends Service {
   constructor(
     private readonly departureClientFactory: RestClientBuilder<DepartureClient>,
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
-  ) {}
+  ) {
+    super()
+  }
 
   async createDeparture(premisesId: string, bookingId: string, departure: DepartureDto): Promise<Departure> {
     const departureClient = this.departureClientFactory(this.token)

--- a/server/services/nonArrivalService.test.ts
+++ b/server/services/nonArrivalService.test.ts
@@ -3,20 +3,22 @@ import type { NonArrival } from 'approved-premises'
 import NonArrivalService from './nonArrivalService'
 import NonArrivalClient from '../data/nonArrivalClient'
 import NonArrivalFactory from '../testutils/factories/nonArrival'
+import itGetsATokenFromARequest from './shared_examples'
 
 jest.mock('../data/nonArrivalClient.ts')
 
 describe('NonArrivalService', () => {
   const nonArrivalClient = new NonArrivalClient(null) as jest.Mocked<NonArrivalClient>
-  let service: NonArrivalService
-
   const nonArrivalClientFactory = jest.fn()
+
+  const service = new NonArrivalService(nonArrivalClientFactory)
 
   beforeEach(() => {
     jest.resetAllMocks()
     nonArrivalClientFactory.mockReturnValue(nonArrivalClient)
-    service = new NonArrivalService(nonArrivalClientFactory)
   })
+
+  itGetsATokenFromARequest(service)
 
   describe('createNonArrival', () => {
     it('on success returns the arrival that has been posted', async () => {

--- a/server/services/nonArrivalService.ts
+++ b/server/services/nonArrivalService.ts
@@ -1,12 +1,11 @@
 import type { NonArrival } from 'approved-premises'
 import type { RestClientBuilder, NonArrivalClient } from '../data'
+import Service from './service'
 
-export default class NonArrivalService {
-  // TODO: We need to do some more work on authentication to work
-  // out how to get this token, so let's stub for now
-  token = 'FAKE_TOKEN'
-
-  constructor(private readonly nonArrivalClientFactory: RestClientBuilder<NonArrivalClient>) {}
+export default class NonArrivalService extends Service {
+  constructor(private readonly nonArrivalClientFactory: RestClientBuilder<NonArrivalClient>) {
+    super()
+  }
 
   async createNonArrival(
     premisesId: string,

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -2,20 +2,22 @@ import PremisesService from './premisesService'
 import PremisesClient from '../data/premisesClient'
 
 import premisesFactory from '../testutils/factories/premises'
+import itGetsATokenFromARequest from './shared_examples'
 
 jest.mock('../data/premisesClient')
 
 describe('PremisesService', () => {
   const premisesClient = new PremisesClient(null) as jest.Mocked<PremisesClient>
-  let service: PremisesService
-
   const premisesClientFactory = jest.fn()
+
+  const service = new PremisesService(premisesClientFactory)
 
   beforeEach(() => {
     jest.resetAllMocks()
     premisesClientFactory.mockReturnValue(premisesClient)
-    service = new PremisesService(premisesClientFactory)
   })
+
+  itGetsATokenFromARequest(service)
 
   describe('tableRows', () => {
     it('returns a table view of the premises', async () => {

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -1,12 +1,11 @@
 import type { Premises, TableRow, SummaryList } from 'approved-premises'
 import type { RestClientBuilder, PremisesClient } from '../data'
+import Service from './service'
 
-export default class PremisesService {
-  // TODO: We need to do some more work on authentication to work
-  // out how to get this token, so let's stub for now
-  token = 'FAKE_TOKEN'
-
-  constructor(private readonly premisesClientFactory: RestClientBuilder<PremisesClient>) {}
+export default class PremisesService extends Service {
+  constructor(private readonly premisesClientFactory: RestClientBuilder<PremisesClient>) {
+    super()
+  }
 
   async tableRows(): Promise<Array<TableRow>> {
     const premisesClient = this.premisesClientFactory(this.token)

--- a/server/services/service.ts
+++ b/server/services/service.ts
@@ -1,0 +1,10 @@
+import type { Request } from 'express'
+
+export default class Service {
+  token: string
+
+  withTokenFromRequest(request: Request): typeof this {
+    this.token = request.user.token
+    return this
+  }
+}

--- a/server/services/shared_examples/index.ts
+++ b/server/services/shared_examples/index.ts
@@ -1,0 +1,20 @@
+import type { Request } from 'express'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { createMock } from '@golevelup/ts-jest'
+
+import Service from '../service'
+
+export default function itGetsATokenFromARequest(service: Service) {
+  describe('withTokenFromRequest', () => {
+    const request = createMock<Request>({ user: { token: 'some-token' } })
+    const result = service.withTokenFromRequest(request)
+
+    it('should extract a token from the request', () => {
+      expect(result.token).toEqual('some-token')
+    })
+
+    it('should return the object', () => {
+      expect(result).toEqual(service)
+    })
+  })
+}


### PR DESCRIPTION
Previously, we were just passing a stub `TOKEN` variable to the stub APIs, now we're starting to think about integrating with the API, we need to pass actual tokens from HMPPS Auth. I've done this by adding a `withTokenFromRequest` method to all of our services, this accepts an Express Request object, extracts the token from the session, passes it to the initialized service, then returns the object (to allow for method chaining). This ensures we can seperate the concerns of our service methods and ensure we don't have to carry out repetitive actions in our controllers.