### PR TITLE
(548) Create a lost bed

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,6 +8,7 @@ import arrival from './integration_tests/mockApis/arrival'
 import nonArrival from './integration_tests/mockApis/nonArrival'
 import departure from './integration_tests/mockApis/departure'
 import cancellation from './integration_tests/mockApis/cancellation'
+import lostBed from './integration_tests/mockApis/lostBed'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -34,6 +35,7 @@ export default defineConfig({
         ...booking,
         ...departure,
         ...cancellation,
+        ...lostBed,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/integration_tests/e2e/cancellation.cy.ts
+++ b/integration_tests/e2e/cancellation.cy.ts
@@ -5,7 +5,7 @@ import cancellationFactory from '../../server/testutils/factories/cancellation'
 import CancellationCreatePage from '../pages/cancellationCreate'
 import CancellationConfirmPage from '../pages/cancellationConfirmation'
 
-context('Booking', () => {
+context('Cancellation', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
@@ -48,7 +48,7 @@ context('Booking', () => {
 
     // And I should see a confirmation screen for that cancellation
     const cancellationConfirmationPage = new CancellationConfirmPage()
-    cancellationConfirmationPage.verifyConfirmedCancellatiobIsVisible(cancellation, booking)
+    cancellationConfirmationPage.verifyConfirmedCancellationIsVisible(cancellation, booking)
   })
 
   it('should show errors', () => {

--- a/integration_tests/e2e/lostBed.cy.ts
+++ b/integration_tests/e2e/lostBed.cy.ts
@@ -1,0 +1,75 @@
+import premisesFactory from '../../server/testutils/factories/premises'
+import lostBedFactory from '../../server/testutils/factories/lostBed'
+
+import LostBedCreatePage from '../pages/lostBedCreate'
+
+context('LostBed', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+    cy.task('stubLostBedReferenceData')
+  })
+
+  it('should allow me to create a lost bed', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    const premises = premisesFactory.build()
+    cy.task('stubSinglePremises', premises)
+
+    // When I navigate to the lost bed form
+    const lostBed = lostBedFactory.build({
+      startDate: new Date(2022, 1, 11, 0, 0).toISOString(),
+      endDate: new Date(2022, 2, 11, 0, 0).toISOString(),
+    })
+    cy.task('stubLostBedCreate', { premisesId: premises.id, lostBed })
+
+    const page = LostBedCreatePage.visit(premises.id)
+
+    // And I fill out the form
+    page.completeForm(lostBed)
+    page.clickSubmit()
+
+    // Then a lost bed should have been created in the API
+    cy.task('verifyLostBedCreate', {
+      premisesId: premises.id,
+      lostBed,
+    }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+
+      expect(requestBody.startDate).equal(lostBed.startDate)
+      expect(requestBody.endDate).equal(lostBed.endDate)
+      expect(requestBody.notes).equal(lostBed.notes)
+      expect(requestBody.reason).equal(lostBed.reason.id)
+      expect(requestBody.numberOfBeds).equal(lostBed.numberOfBeds.toString())
+      expect(requestBody.referenceNumber).equal(lostBed.referenceNumber)
+    })
+
+    // And I should be navigated to the premises detail page and see the confirmation message
+    page.shouldShowBanner('Lost bed logged')
+  })
+
+  it('should show errors', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And a lost bed is available
+    const premises = premisesFactory.build()
+
+    // When I navigate to the lost bed form
+    const page = LostBedCreatePage.visit(premises.id)
+
+    // And I miss required fields
+    cy.task('stubLostBedErrors', {
+      premisesId: premises.id,
+      params: ['numberOfBeds', 'startDate', 'endDate', 'reason', 'referenceNumber'],
+    })
+
+    page.clickSubmit()
+
+    // Then I should see error messages relating to that field
+    page.shouldShowErrorMessagesForFields(['numberOfBeds', 'startDate', 'endDate', 'reason', 'referenceNumber'])
+  })
+})

--- a/integration_tests/mockApis/lostBed.ts
+++ b/integration_tests/mockApis/lostBed.ts
@@ -1,0 +1,35 @@
+import { SuperAgentRequest, Response } from 'superagent'
+
+import type { LostBed } from 'approved-premises'
+
+import { stubFor, getMatchingRequests } from '../../wiremock'
+import { errorStub } from '../../wiremock/utils'
+import { lostBedReasons } from '../../wiremock/referenceDataStubs'
+
+export default {
+  stubLostBedCreate: (args: { premisesId: string; lostBed: LostBed }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: `/premises/${args.premisesId}/lostBeds`,
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.lostBed,
+      },
+    }),
+
+  stubLostBedErrors: (args: { premisesId: string; params: Array<string> }): SuperAgentRequest =>
+    stubFor(errorStub(args.params, `/premises/${args.premisesId}/lostBeds`, ['notes', 'reason'])),
+
+  stubLostBedReferenceData: (): Promise<Response> => stubFor(lostBedReasons),
+
+  verifyLostBedCreate: async (args: { premisesId: string; bookingId: string }) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: `/premises/${args.premisesId}/lostBeds`,
+      })
+    ).body.requests,
+}

--- a/integration_tests/pages/cancellationConfirmation.ts
+++ b/integration_tests/pages/cancellationConfirmation.ts
@@ -8,7 +8,7 @@ export default class CancellationConfirmPage extends Page {
     super('Cancellation complete')
   }
 
-  verifyConfirmedCancellatiobIsVisible(cancellation: Cancellation, booking: Booking): void {
+  verifyConfirmedCancellationIsVisible(cancellation: Cancellation, booking: Booking): void {
     cy.get('dl').within(() => {
       this.assertDefinition('Name', booking.name)
       this.assertDefinition('CRN', booking.crn)

--- a/integration_tests/pages/lostBedCreate.ts
+++ b/integration_tests/pages/lostBedCreate.ts
@@ -1,0 +1,39 @@
+import type { LostBed } from 'approved-premises'
+
+import Page from './page'
+
+export default class LostBedCreatePage extends Page {
+  constructor() {
+    super('Record a lost bed')
+  }
+
+  static visit(premisesId: string): LostBedCreatePage {
+    cy.visit(`/premises/${premisesId}/lostBeds/new`)
+    return new LostBedCreatePage()
+  }
+
+  public completeForm(lostBed: LostBed): void {
+    cy.get('input[name="lostBed[numberOfBeds]"]').type(lostBed.numberOfBeds.toString())
+
+    const startDate = new Date(Date.parse(lostBed.startDate))
+    const endDate = new Date(Date.parse(lostBed.endDate))
+
+    cy.get('input[name="startDate-day"]').type(String(startDate.getDate()))
+    cy.get('input[name="startDate-month"]').type(String(startDate.getMonth() + 1))
+    cy.get('input[name="startDate-year"]').type(String(startDate.getFullYear()))
+
+    cy.get('input[name="endDate-day"]').type(String(endDate.getDate()))
+    cy.get('input[name="endDate-month"]').type(String(endDate.getMonth() + 1))
+    cy.get('input[name="endDate-year"]').type(String(endDate.getFullYear()))
+
+    cy.get('input[name="lostBed[referenceNumber]"]').type(lostBed.referenceNumber)
+
+    cy.get(`input[name="lostBed[reason]"][value="${lostBed.reason.id}"]`).check()
+
+    cy.get('[name="lostBed[notes]"]').type(lostBed.notes)
+  }
+
+  public clickSubmit(): void {
+    cy.get('[name="lostBed[submit]"]').click()
+  }
+}

--- a/integration_tests/pages/premisesList.ts
+++ b/integration_tests/pages/premisesList.ts
@@ -23,8 +23,4 @@ export default class PremisesListPage extends Page {
         })
     })
   }
-
-  static shouldShowFlashMessage(): void {
-    cy.get('.govuk-notification-banner__content').should('contain', 'Booking made successfully')
-  }
 }

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -4,6 +4,7 @@ declare module 'approved-premises' {
   export type NonArrival = schemas['NonArrival']
   export type Departure = schemas['Departure']
   export type Booking = schemas['Booking']
+  export type LostBed = schemas['LostBed']
   export type ReferenceData = schemas['ReferenceData']
   export type Cancellation = schemas['Cancellation']
   export type KeyWorker = schemas['KeyWorker']
@@ -39,6 +40,12 @@ declare module 'approved-premises' {
 
   export type CancellationDto = Omit<Cancellation, 'id' | 'bookingId' | 'reason'> &
     ObjectWithDateParts<'date'> & {
+      reason: string
+    }
+
+  export type LostBedDto = Omit<LostBed, 'id' | 'reason'> &
+    ObjectWithDateParts<'startDate'> &
+    ObjectWithDateParts<'endDate'> & {
       reason: string
     }
 
@@ -180,6 +187,15 @@ declare module 'approved-premises' {
       date: string
       reason: ReferenceData
       notes: string
+    }
+    LostBed: {
+      id: string
+      startDate: string
+      endDate: string
+      numberOfBeds: number
+      referenceNumber: string
+      notes: string
+      reason: ReferenceData
     }
   }
 }

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -9,6 +9,7 @@ import DeparturesController from './departuresController'
 import CancellationsController from './cancellationsController'
 
 import type { Services } from '../services'
+import LostBedsController from './lostBedsController'
 
 export const controllers = (services: Services) => {
   const applicationController = new ApplicationController()
@@ -22,6 +23,7 @@ export const controllers = (services: Services) => {
     services.bookingService,
   )
   const cancellationsController = new CancellationsController(services.cancellationService, services.bookingService)
+  const lostBedsController = new LostBedsController(services.lostBedService)
 
   return {
     applicationController,
@@ -31,9 +33,17 @@ export const controllers = (services: Services) => {
     nonArrivalsController,
     departuresController,
     cancellationsController,
+    lostBedsController,
   }
 }
 
 export type Controllers = ReturnType<typeof controllers>
 
-export { PremisesController, BookingsController, ArrivalsController, NonArrivalsController, DeparturesController }
+export {
+  PremisesController,
+  BookingsController,
+  ArrivalsController,
+  NonArrivalsController,
+  DeparturesController,
+  LostBedsController,
+}

--- a/server/controllers/lostBedsController.test.ts
+++ b/server/controllers/lostBedsController.test.ts
@@ -1,0 +1,130 @@
+import type { Request, Response, NextFunction } from 'express'
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
+import type { ErrorsAndUserInput } from 'approved-premises'
+import LostBedService, { LostBedReferenceData } from '../services/lostBedService'
+import LostBedsController from './lostBedsController'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../utils/validation'
+import lostBedFactory from '../testutils/factories/lostBed'
+
+jest.mock('../utils/validation')
+
+describe('LostBedsController', () => {
+  const token = 'SOME_TOKEN'
+
+  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const lostBedService = createMock<LostBedService>({})
+
+  const lostBedController = new LostBedsController(lostBedService)
+  const premisesId = 'premisesId'
+
+  describe('new', () => {
+    it('renders the form', async () => {
+      const lostBedReasons = createMock<LostBedReferenceData>()
+      lostBedService.getReferenceData.mockResolvedValue(lostBedReasons)
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [], userInput: {} })
+
+      const requestHandler = lostBedController.new()
+
+      request.params = {
+        premisesId,
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('lostBeds/new', {
+        premisesId,
+        lostBedReasons,
+        errors: {},
+        errorSummary: [],
+      })
+      expect(lostBedService.getReferenceData).toHaveBeenCalledWith(token)
+    })
+
+    it('renders the form with errors and user input if an error has been sent to the flash', async () => {
+      const lostBedReasons = createMock<LostBedReferenceData>()
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+
+      lostBedService.getReferenceData.mockResolvedValue(lostBedReasons)
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+
+      const requestHandler = lostBedController.new()
+
+      request.params = {
+        premisesId,
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('lostBeds/new', {
+        premisesId,
+        lostBedReasons,
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        ...errorsAndUserInput.userInput,
+      })
+    })
+  })
+
+  describe('create', () => {
+    it('creates a lost bed and redirects to the premises page', async () => {
+      const lostBed = lostBedFactory.build()
+      lostBedService.createLostBed.mockResolvedValue(lostBed)
+
+      const requestHandler = lostBedController.create()
+
+      request.params = {
+        premisesId,
+      }
+
+      request.body = {
+        'startDate-year': 2022,
+        'startDate-month': 8,
+        'startDate-day': 22,
+        'endDate-year': 2022,
+        'endDate-month': 9,
+        'endDate-day': 22,
+        notes: lostBed.notes,
+        reason: lostBed.reason,
+        referenceNumber: lostBed.referenceNumber,
+        numberOfBeds: lostBed.numberOfBeds,
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(lostBedService.createLostBed).toHaveBeenCalledWith(token, request.params.premisesId, {
+        ...request.body.lostBed,
+        startDate: '2022-08-22T00:00:00.000Z',
+        endDate: '2022-09-22T00:00:00.000Z',
+      })
+      expect(request.flash).toHaveBeenCalledWith('success', 'Lost bed logged')
+      expect(response.redirect).toHaveBeenCalledWith(`/premises/${request.params.premisesId}`)
+    })
+
+    it('renders with errors if the API returns an error', async () => {
+      const requestHandler = lostBedController.create()
+
+      request.params = {
+        premisesId,
+      }
+
+      const err = new Error()
+
+      lostBedService.createLostBed.mockImplementation(() => {
+        throw err
+      })
+
+      await requestHandler(request, response, next)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        err,
+        `/premises/${request.params.premisesId}/lostBeds/new`,
+      )
+    })
+  })
+})

--- a/server/controllers/lostBedsController.ts
+++ b/server/controllers/lostBedsController.ts
@@ -1,0 +1,47 @@
+import type { Response, Request, RequestHandler } from 'express'
+
+import type { LostBedDto } from 'approved-premises'
+import LostBedService from '../services/lostBedService'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../utils/validation'
+import { convertDateAndTimeInputsToIsoString } from '../utils/utils'
+
+export default class LostBedsController {
+  constructor(private readonly lostBedService: LostBedService) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId } = req.params
+      const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
+
+      const lostBedReasons = await this.lostBedService.getReferenceData(req.user.token)
+
+      res.render('lostBeds/new', {
+        premisesId,
+        lostBedReasons,
+        errors,
+        errorSummary,
+        ...userInput,
+      })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId } = req.params
+
+      const { startDate } = convertDateAndTimeInputsToIsoString(req.body, 'startDate')
+      const { endDate } = convertDateAndTimeInputsToIsoString(req.body, 'endDate')
+
+      const lostBed: LostBedDto = { ...req.body.lostBed, startDate, endDate }
+
+      try {
+        await this.lostBedService.createLostBed(req.user.token, premisesId, lostBed)
+
+        req.flash('success', 'Lost bed logged')
+        res.redirect(`/premises/${premisesId}`)
+      } catch (err) {
+        catchValidationErrorOrPropogate(req, res, err, `/premises/${premisesId}/lostBeds/new`)
+      }
+    }
+  }
+}

--- a/server/controllers/premisesController.test.ts
+++ b/server/controllers/premisesController.test.ts
@@ -44,7 +44,12 @@ describe('PremisesController', () => {
       const requestHandler = premisesController.show()
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('premises/show', { premises, bookings, currentResidents })
+      expect(response.render).toHaveBeenCalledWith('premises/show', {
+        premisesId: 'some-uuid',
+        premises,
+        bookings,
+        currentResidents,
+      })
 
       expect(premisesService.getPremisesDetails).toHaveBeenCalledWith(token, 'some-uuid')
       expect(bookingService.groupedListOfBookingsForPremisesId).toHaveBeenCalledWith(token, 'some-uuid')

--- a/server/controllers/premisesController.ts
+++ b/server/controllers/premisesController.ts
@@ -20,7 +20,7 @@ export default class PremisesController {
       const bookings = await this.bookingService.groupedListOfBookingsForPremisesId(req.user.token, req.params.id)
       const currentResidents = await this.bookingService.currentResidents(req.user.token, req.params.id)
 
-      return res.render('premises/show', { premises, bookings, currentResidents })
+      return res.render('premises/show', { premises, premisesId: req.params.id, bookings, currentResidents })
     }
   }
 }

--- a/server/data/arrivalClient.test.ts
+++ b/server/data/arrivalClient.test.ts
@@ -4,7 +4,7 @@ import ArrivalClient from './arrivalClient'
 import config from '../config'
 import arrivalFactory from '../testutils/factories/arrival'
 
-describe('PremisesClient', () => {
+describe('ArrivalClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let arrivalClient: ArrivalClient
 

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -21,6 +21,7 @@ import CancellationClient from './cancellationClient'
 
 import { createRedisClient } from './redisClient'
 import TokenStore from './tokenStore'
+import LostBedClient from './lostBedClient'
 
 type RestClientBuilder<T> = (token: string) => T
 
@@ -35,6 +36,7 @@ export const dataAccess = () => ({
     new ReferenceDataClient(token)) as RestClientBuilder<ReferenceDataClient>,
   cancellationClientBuilder: ((token: string) =>
     new CancellationClient(token)) as RestClientBuilder<CancellationClient>,
+  lostBedClientBuilder: ((token: string) => new LostBedClient(token)) as RestClientBuilder<LostBedClient>,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>
@@ -49,4 +51,5 @@ export {
   DepartureClient,
   ReferenceDataClient,
   CancellationClient,
+  LostBedClient,
 }

--- a/server/data/lostBedClient.test.ts
+++ b/server/data/lostBedClient.test.ts
@@ -1,0 +1,45 @@
+import nock from 'nock'
+
+import LostBedClient from './lostBedClient'
+import config from '../config'
+import lostBedFactory from '../testutils/factories/lostBed'
+import lostBedDtoFactory from '../testutils/factories/lostBedDto'
+
+describe('LostBedClient', () => {
+  let fakeApprovedPremisesApi: nock.Scope
+  let lostBedClient: LostBedClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    config.apis.approvedPremises.url = 'http://localhost:8080'
+    fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
+    lostBedClient = new LostBedClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('create', () => {
+    it('should create a lostBed', async () => {
+      const lostBed = lostBedFactory.build()
+      const lostBedDto = lostBedDtoFactory.build()
+
+      fakeApprovedPremisesApi
+        .post(`/premises/premisesId/lostBeds`, lostBedDto)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, lostBed)
+
+      const result = await lostBedClient.create('premisesId', lostBedDto)
+
+      expect(result).toEqual(lostBed)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+})

--- a/server/data/lostBedClient.ts
+++ b/server/data/lostBedClient.ts
@@ -1,0 +1,20 @@
+import type { LostBed, LostBedDto } from 'approved-premises'
+import RestClient from './restClient'
+import config, { ApiConfig } from '../config'
+
+export default class LostBedClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('lostBedClient', config.apis.approvedPremises as ApiConfig, token)
+  }
+
+  async create(premisesId: string, lostBed: LostBedDto): Promise<LostBed> {
+    const response = await this.restClient.post({
+      path: `/premises/${premisesId}/lostBeds`,
+      data: lostBed,
+    })
+
+    return response as LostBed
+  }
+}

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -24,5 +24,9 @@
     "blank": "You must enter a valid departure date and time"
   },
   "moveOnCategory": { "blank": "You must enter a move on category" },
-  "destinationProvider": { "blank": "You must enter a destination provider" }
+  "destinationProvider": { "blank": "You must enter a destination provider" },
+  "startDate": { "blank": "You must enter a start date" },
+  "endDate": { "blank": "You must enter a end date" },
+  "numberOfBeds": { "blank": "You must enter the number of beds lost" },
+  "referenceNumber": { "blank": "You must enter a reference number" }
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -16,6 +16,7 @@ export default function routes(controllers: Controllers): Router {
     nonArrivalsController,
     departuresController,
     cancellationsController,
+    lostBedsController,
   } = controllers
 
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
@@ -42,6 +43,9 @@ export default function routes(controllers: Controllers): Router {
   get('/premises/:premisesId/bookings/:bookingId/departures/new', departuresController.new())
   post('/premises/:premisesId/bookings/:bookingId/departures', departuresController.create())
   get('/premises/:premisesId/bookings/:bookingId/departures/:departureId/confirmation', departuresController.confirm())
+
+  get('/premises/:premisesId/lostBeds/new', lostBedsController.new())
+  post('/premises/:premisesId/lostBeds', lostBedsController.create())
 
   return router
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -9,6 +9,7 @@ import ArrivalService from './arrivalService'
 import NonArrivalService from './nonArrivalService'
 import DepartureService from './departureService'
 import CancellationService from './cancellationService'
+import LostBedService from './lostBedService'
 
 export const services = () => {
   const {
@@ -20,6 +21,7 @@ export const services = () => {
     departureClientBuilder,
     referenceDataClientBuilder,
     cancellationClientBuilder,
+    lostBedClientBuilder,
   } = dataAccess()
 
   const userService = new UserService(hmppsAuthClient)
@@ -29,6 +31,7 @@ export const services = () => {
   const nonArrivalService = new NonArrivalService(nonArrivalClientBuilder)
   const departureService = new DepartureService(departureClientBuilder, referenceDataClientBuilder)
   const cancellationService = new CancellationService(cancellationClientBuilder, referenceDataClientBuilder)
+  const lostBedService = new LostBedService(lostBedClientBuilder, referenceDataClientBuilder)
 
   return {
     userService,
@@ -38,6 +41,7 @@ export const services = () => {
     nonArrivalService,
     departureService,
     cancellationService,
+    lostBedService,
   }
 }
 
@@ -51,4 +55,5 @@ export {
   DepartureService,
   CancellationService,
   BookingService,
+  LostBedService,
 }

--- a/server/services/lostBedService.test.ts
+++ b/server/services/lostBedService.test.ts
@@ -1,0 +1,65 @@
+import type { LostBed, LostBedDto } from 'approved-premises'
+
+import LostBedService from './lostBedService'
+import LostBedClient from '../data/lostBedClient'
+import ReferenceDataClient from '../data/referenceDataClient'
+
+import lostBedFactory from '../testutils/factories/lostBed'
+import lostBedDtoFactory from '../testutils/factories/lostBedDto'
+import referenceDataFactory from '../testutils/factories/referenceData'
+
+jest.mock('../data/lostBedClient.ts')
+jest.mock('../data/referenceDataClient.ts')
+
+describe('LostBedService', () => {
+  const lostBedClient = new LostBedClient(null) as jest.Mocked<LostBedClient>
+  const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
+
+  const LostBedClientFactory = jest.fn()
+  const ReferenceDataClientFactory = jest.fn()
+
+  const service = new LostBedService(LostBedClientFactory, ReferenceDataClientFactory)
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    LostBedClientFactory.mockReturnValue(lostBedClient)
+    ReferenceDataClientFactory.mockReturnValue(referenceDataClient)
+  })
+
+  describe('createLostBed', () => {
+    it('on success returns the lostBed that has been posted', async () => {
+      const lostBed: LostBed = lostBedFactory.build()
+      const lostBedDto: LostBedDto = lostBedDtoFactory.build()
+
+      const token = 'SOME_TOKEN'
+      lostBedClient.create.mockResolvedValue(lostBed)
+
+      const postedLostBed = await service.createLostBed(token, 'premisesID', lostBedDto)
+
+      expect(postedLostBed).toEqual(lostBed)
+      expect(LostBedClientFactory).toHaveBeenCalledWith(token)
+      expect(lostBedClient.create).toHaveBeenCalledWith('premisesID', lostBedDto)
+    })
+  })
+
+  describe('getReferenceData', () => {
+    it('should return the lost bed reasons data needed', async () => {
+      const lostBedReasons = referenceDataFactory.buildList(2)
+      const token = 'SOME_TOKEN'
+
+      referenceDataClient.getReferenceData.mockImplementation(category => {
+        return Promise.resolve(
+          {
+            'lost-bed-reasons': lostBedReasons,
+          }[category],
+        )
+      })
+
+      const result = await service.getReferenceData(token)
+
+      expect(result).toEqual(lostBedReasons)
+      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('lost-bed-reasons')
+    })
+  })
+})

--- a/server/services/lostBedService.ts
+++ b/server/services/lostBedService.ts
@@ -1,0 +1,26 @@
+import type { LostBed, LostBedDto, ReferenceData } from 'approved-premises'
+import type { RestClientBuilder, LostBedClient, ReferenceDataClient } from '../data'
+
+export type LostBedReferenceData = Array<ReferenceData>
+export default class LostBedService {
+  constructor(
+    private readonly lostBedClientFactory: RestClientBuilder<LostBedClient>,
+    private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
+  ) {}
+
+  async createLostBed(token: string, premisesId: string, lostBed: LostBedDto): Promise<LostBed> {
+    const lostBedClient = this.lostBedClientFactory(token)
+
+    const confirmedLostBed = await lostBedClient.create(premisesId, lostBed)
+
+    return confirmedLostBed
+  }
+
+  async getReferenceData(token: string): Promise<LostBedReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(token)
+
+    const reasons = await referenceDataClient.getReferenceData('lost-bed-reasons')
+
+    return reasons
+  }
+}

--- a/server/testutils/factories/lostBed.ts
+++ b/server/testutils/factories/lostBed.ts
@@ -1,0 +1,15 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { LostBed } from 'approved-premises'
+import referenceDataFactory from './referenceData'
+
+export default Factory.define<LostBed>(() => ({
+  id: faker.datatype.uuid(),
+  notes: faker.lorem.sentence(),
+  startDate: faker.date.soon().toISOString(),
+  endDate: faker.date.future().toISOString(),
+  numberOfBeds: faker.datatype.number({ max: 10 }),
+  referenceNumber: faker.datatype.uuid(),
+  reason: referenceDataFactory.lostBedReasons().build(),
+}))

--- a/server/testutils/factories/lostBedDto.ts
+++ b/server/testutils/factories/lostBedDto.ts
@@ -1,0 +1,25 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { LostBedDto } from 'approved-premises'
+import referenceDataFactory from './referenceData'
+
+export default Factory.define<LostBedDto>(() => {
+  const startDate = faker.date.soon()
+  const endDate = faker.date.future()
+  return {
+    id: faker.datatype.uuid(),
+    notes: faker.lorem.sentence(),
+    startDate: startDate.toISOString(),
+    'startDate-day': startDate.getDate().toString(),
+    'startDate-month': startDate.getMonth().toString(),
+    'startDate-year': startDate.getFullYear().toString(),
+    endDate: endDate.toISOString(),
+    'endDate-day': endDate.getDate().toString(),
+    'endDate-month': endDate.getMonth().toString(),
+    'endDate-year': endDate.getFullYear().toString(),
+    numberOfBeds: faker.datatype.number({ max: 10 }),
+    referenceNumber: faker.datatype.uuid(),
+    reason: referenceDataFactory.lostBedReasons().build().id,
+  }
+})

--- a/server/testutils/factories/referenceData.ts
+++ b/server/testutils/factories/referenceData.ts
@@ -7,6 +7,7 @@ import departureReasonsJson from '../../../wiremock/stubs/departure-reasons.json
 import moveOnCategoriesJson from '../../../wiremock/stubs/move-on-categories.json'
 import destinationProvidersJson from '../../../wiremock/stubs/destination-providers.json'
 import cancellationReasonsJson from '../../../wiremock/stubs/cancellation-reasons.json'
+import lostBedReasonsJson from '../../../wiremock/stubs/lost-bed-reasons.json'
 
 class ReferenceDataFactory extends Factory<ReferenceData> {
   departureReasons() {
@@ -26,6 +27,11 @@ class ReferenceDataFactory extends Factory<ReferenceData> {
 
   cancellationReasons() {
     const data = faker.helpers.arrayElement(cancellationReasonsJson)
+    return this.params(data)
+  }
+
+  lostBedReasons() {
+    const data = faker.helpers.arrayElement(lostBedReasonsJson)
     return this.params(data)
   }
 }

--- a/server/views/lostBeds/new.njk
+++ b/server/views/lostBeds/new.njk
@@ -1,0 +1,110 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "../partials/showErrorSummary.njk" import showErrorSummary %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Record a lost bed" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {{ govukBackLink({
+        text: "Back",
+        href: "/premises/" + premisesId 
+      }) }}
+
+      <form action="/premises/{{premisesId}}/lostBeds" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ showErrorSummary(errorSummary) }}
+
+        <h1 class="govuk-!-margin-bottom-0">Record a lost bed</h1>
+        <p> Record beds that have been lost within your AP estate.</p>
+
+        {{ govukInput({
+        label: {
+          text: "Number of beds lost"
+        },
+        classes: "govuk-input--width-2",
+        id: "numberOfBeds",
+        name: "lostBed[numberOfBeds]",
+        errorMessage: errors.numberOfBeds
+      }) }}
+
+        {{ govukDateInput({
+        id: "startDate",
+        namePrefix: "startDate",
+        items: dateFieldValues('startDate', errors),
+        errorMessage: errors.startDate,
+        fieldset: {
+          legend: {
+            text: "Start date",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--s"
+          }
+        }
+      }) }}
+
+        {{ govukDateInput({
+        id: "endDate",
+        namePrefix: "endDate",
+        items: dateFieldValues('endDate', errors),
+        errorMessage: errors.endDate,
+        fieldset: {
+          legend: {
+            text: "End date",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--s"
+          }
+        }
+      }) }}
+
+        {{ govukRadios({
+        idPrefix: "reason",
+        name: "lostBed[reason]",
+        fieldset: {
+          legend: {
+            text: "What is the reason for marking this bed as lost?",
+            classes: "govuk-fieldset__legend--s"
+          }
+        },
+        items: convertObjectsToRadioItems(lostBedReasons, 'name', 'id', 'lostBed[reason]'),
+        errorMessage: errors.reason
+      }) }}
+
+        {{ govukInput({
+        label: {
+          text: "Reference number"
+        },
+        classes: "govuk-input--width-6",
+        id: "referenceNumber",
+        name: "lostBed[referenceNumber]",
+        errorMessage: errors.referenceNumber
+      }) }}
+
+        {{ govukTextarea({
+        id: "notes",
+        name: "lostBed[notes]",
+        label: {
+          text: "Additional notes"
+        },
+        errorMessage: errors.notes
+      }) }}
+
+        {{ govukButton({
+          text: "Save and continue",
+          name: "lostBed[submit]"
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/server/views/premises/show.njk
+++ b/server/views/premises/show.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "../bookings/_table.njk" import bookingTable %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -79,5 +80,13 @@
     ],
     rows: currentResidents
   }) }}
+
+  <h2>Log a lost bed</h2>
+
+  {{ govukButton({
+            text: "Log", 
+            type: 'button',
+            href: '/premises/{{premisesId}}/lostBeds/new'
+        }) }}
 
 {% endblock %}

--- a/wiremock/lostBedStubs.ts
+++ b/wiremock/lostBedStubs.ts
@@ -1,0 +1,27 @@
+import { guidRegex } from './index'
+import lostBedFactory from '../server/testutils/factories/lostBed'
+import { errorStub, getCombinations } from './utils'
+
+const lostBeds: Array<Record<string, unknown>> = []
+
+lostBeds.push({
+  priority: 99,
+  request: {
+    method: 'POST',
+    urlPathPattern: `/premises/${guidRegex}/lostBeds`,
+  },
+  response: {
+    status: 201,
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+    },
+    jsonBody: JSON.stringify(lostBedFactory.build()),
+  },
+})
+const requiredFields = getCombinations(['startDate', 'endDate', 'numberOfBeds', 'reason', 'referenceNumber'])
+
+requiredFields.forEach((fields: Array<string>) => {
+  lostBeds.push(errorStub(fields, `/premises/${guidRegex}/lostBeds`, ['notes', 'reason']))
+})
+
+export default lostBeds

--- a/wiremock/referenceDataStubs.ts
+++ b/wiremock/referenceDataStubs.ts
@@ -2,6 +2,7 @@ import departureReasonsJson from './stubs/departure-reasons.json'
 import moveOnCategoriesJson from './stubs/move-on-categories.json'
 import destinationProvidersJson from './stubs/destination-providers.json'
 import cancellationReasonsJson from './stubs/cancellation-reasons.json'
+import lostBedReasonsJson from './stubs/lost-bed-reasons.json'
 
 const departureReasons = {
   request: {
@@ -59,4 +60,18 @@ const cancellationReasons = {
   },
 }
 
-export { departureReasons, moveOnCategories, destinationProviders, cancellationReasons }
+const lostBedReasons = {
+  request: {
+    method: 'GET',
+    url: '/reference-data/lost-bed-reasons',
+  },
+  response: {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+    },
+    jsonBody: lostBedReasonsJson,
+  },
+}
+
+export { departureReasons, moveOnCategories, destinationProviders, cancellationReasons, lostBedReasons }

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -13,6 +13,7 @@ import arrivalStubs from './arrivalStubs'
 import nonArrivalStubs from './nonArrivalStubs'
 import departureStubs from './departuresStubs'
 import cancellationStubs from './cancellationStubs'
+import lostBedStubs from './lostBedStubs'
 
 import * as referenceDataStubs from './referenceDataStubs'
 
@@ -98,6 +99,7 @@ stubs.push(
   ...nonArrivalStubs,
   ...departureStubs,
   ...cancellationStubs,
+  ...lostBedStubs,
   ...Object.values(referenceDataStubs),
 )
 

--- a/wiremock/stubs/lost-bed-reasons.json
+++ b/wiremock/stubs/lost-bed-reasons.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "78b9c1a4-1d60-11ed-861d-0242ac120002",
+    "name": "Fire",
+    "isActive": true
+  },
+  {
+    "id": "51b44b8c-f7f3-415d-90c3-61bb7fb96286",
+    "name": "Damaged",
+    "isActive": true
+  },
+  {
+    "id": "9ddc9bfc-72fa-4a25-88c0-cc0ff8c6c00e",
+    "name": "Refurbishment",
+    "isActive": true
+  },
+  {
+    "id": "7f3eb6cd-b3fc-4a8d-b9ce-5959918ffbe8",
+    "name": "Staff shortage",
+    "isActive": true
+  }
+]


### PR DESCRIPTION
# Context

We need to be able to mark when an AP has lost beds (IE the beds are not longer usable).
This follows a very similar pattern to the other features: the controller calls the service which calls the client which calls the API.
We present the user with a form requesting the neccessary information and once they have submitted the form they are presented with a confirmation screen.
The confirmation screen is very rudimentary for now but short of displaying info from the lost bed that has just been created I'm not sure what else it can say.

[Trello ticket](https://trello.com/c/hb3Qw5Wz/548-allow-users-to-create-a-lost-bed-incident-in-the-ui)

## Screenshots of UI changes

![image](https://user-images.githubusercontent.com/44123869/186445823-4bd1b81d-0dd9-4ad9-a327-1b0d1eb3b528.png)
![image](https://user-images.githubusercontent.com/44123869/186446128-f1ac37b2-7da4-4d13-8a13-091c1338ce3e.png)

