### PR TITLE
(537) Extension of bookings

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,6 +4,7 @@ import auth from './integration_tests/mockApis/auth'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
 import premises from './integration_tests/mockApis/premises'
 import booking from './integration_tests/mockApis/booking'
+import bookingExtension from './integration_tests/mockApis/bookingExtension'
 import arrival from './integration_tests/mockApis/arrival'
 import nonArrival from './integration_tests/mockApis/nonArrival'
 import departure from './integration_tests/mockApis/departure'
@@ -22,8 +23,6 @@ export default defineConfig({
   videoUploadOnPasses: false,
   taskTimeout: 60000,
   e2e: {
-    // We've imported your old cypress plugins here.
-    // You may want to clean this up later by importing these.
     setupNodeEvents(on) {
       on('task', {
         reset: resetStubs,
@@ -33,6 +32,7 @@ export default defineConfig({
         ...tokenVerification,
         ...premises,
         ...booking,
+        ...bookingExtension,
         ...departure,
         ...cancellation,
         ...lostBed,

--- a/integration_tests/e2e/booking.cy.ts
+++ b/integration_tests/e2e/booking.cy.ts
@@ -2,10 +2,10 @@ import premisesFactory from '../../server/testutils/factories/premises'
 import bookingFactory from '../../server/testutils/factories/booking'
 import keyWorkerFactory from '../../server/testutils/factories/keyWorker'
 
-import BookingCreatePage from '../pages/bookingCreate'
-import BookingShowPage from '../pages/bookingShow'
+import BookingCreatePage from '../pages/booking/create'
+import BookingShowPage from '../pages/booking/show'
 import Page from '../pages/page'
-import BookingConfirmation from '../pages/bookingConfirmation'
+import BookingConfirmation from '../pages/booking/confirmation'
 
 context('Booking', () => {
   beforeEach(() => {

--- a/integration_tests/e2e/bookingExtension.cy.ts
+++ b/integration_tests/e2e/bookingExtension.cy.ts
@@ -1,0 +1,74 @@
+import premisesFactory from '../../server/testutils/factories/premises'
+import bookingFactory from '../../server/testutils/factories/booking'
+
+import BookingExtensionsConfirmation from '../pages/booking/extension/confirmation'
+import BookingExtensionCreatePage from '../pages/booking/extension/create'
+
+context('BookingExtension', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+  })
+
+  it('should show booking extension form', () => {
+    const booking = bookingFactory.build({
+      expectedDepartureDate: new Date(Date.UTC(2022, 5, 3, 0, 0, 0)).toISOString(),
+    })
+    const newDepartureDate = new Date(Date.UTC(2022, 6, 3, 0, 0, 0)).toISOString()
+    const premises = premisesFactory.build()
+
+    cy.task('stubBookingExtensionCreate', { premisesId: premises.id, booking })
+    cy.task('stubBookingGet', { premisesId: premises.id, booking })
+    cy.task('stubSinglePremises', { premisesId: premises.id, booking })
+
+    // Given I am signed in
+    cy.signIn()
+
+    // When I visit the booking extension page
+    const page = BookingExtensionCreatePage.visit(premises.id, booking.id)
+
+    // And I fill in the extension form
+    page.completeForm(newDepartureDate)
+    page.clickSubmit()
+
+    // Then I should be redirected to the confirmation page
+    const bookingConfirmationPage = new BookingExtensionsConfirmation()
+    bookingConfirmationPage.verifyBookingIsVisible(booking)
+
+    // And the extension should be created in the API
+    cy.task('verifyBookingExtensionCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+
+      expect(requestBody.newDepartureDate).equal(newDepartureDate)
+    })
+  })
+
+  it('should show errors', () => {
+    const premises = premisesFactory.build()
+    const booking = bookingFactory.build({
+      expectedDepartureDate: new Date(Date.UTC(2022, 5, 3, 0, 0, 0)).toISOString(),
+    })
+
+    cy.task('stubSinglePremises', { premisesId: premises.id })
+    cy.task('stubBookingGet', { premisesId: premises.id, booking })
+
+    // Given I am signed in
+    cy.signIn()
+
+    // When I visit the booking extension page
+    const page = BookingExtensionCreatePage.visit(premises.id, booking.id)
+
+    // And I don't enter details into the field
+    cy.task('stubBookingExtensionErrors', {
+      premisesId: premises.id,
+      bookingId: booking.id,
+      params: ['newDepartureDate'],
+    })
+    page.clickSubmit()
+
+    // Then I should see error messages relating to the field
+    page.shouldShowErrorMessagesForFields(['newDepartureDate'])
+  })
+})

--- a/integration_tests/mockApis/bookingExtension.ts
+++ b/integration_tests/mockApis/bookingExtension.ts
@@ -1,0 +1,34 @@
+import { SuperAgentRequest } from 'superagent'
+
+import type { Booking } from 'approved-premises'
+
+import { stubFor, getMatchingRequests } from '../../wiremock'
+import { errorStub } from '../../wiremock/utils'
+
+export default {
+  stubBookingExtensionCreate: (args: { premisesId: string; booking: Booking }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: `/premises/${args.premisesId}/bookings/${args.booking.id}/extensions`,
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.booking,
+      },
+    }),
+  stubBookingExtensionErrors: (args: {
+    premisesId: string
+    bookingId: string
+    params: Array<string>
+  }): SuperAgentRequest =>
+    stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/extensions`)),
+  verifyBookingExtensionCreate: async (args: { premisesId: string; bookingId: string }) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: `/premises/${args.premisesId}/bookings/${args.bookingId}/extensions`,
+      })
+    ).body.requests,
+}

--- a/integration_tests/pages/booking/confirmation.ts
+++ b/integration_tests/pages/booking/confirmation.ts
@@ -1,7 +1,7 @@
 import parseISO from 'date-fns/parseISO'
 import type { Booking } from 'approved-premises'
-import { formatDate } from '../../server/utils/utils'
-import Page from './page'
+import { formatDate } from '../../../server/utils/utils'
+import Page from '../page'
 
 export default class BookingConfirmationPage extends Page {
   constructor() {

--- a/integration_tests/pages/booking/create.ts
+++ b/integration_tests/pages/booking/create.ts
@@ -1,5 +1,5 @@
 import type { Booking } from 'approved-premises'
-import Page, { PageElement } from './page'
+import Page, { PageElement } from '../page'
 
 export default class BookingCreatePage extends Page {
   constructor() {

--- a/integration_tests/pages/booking/extension/confirmation.ts
+++ b/integration_tests/pages/booking/extension/confirmation.ts
@@ -1,0 +1,25 @@
+import parseISO from 'date-fns/parseISO'
+import type { Booking } from 'approved-premises'
+import { formatDate } from '../../../../server/utils/utils'
+import Page from '../../page'
+
+export default class BookingExtensionConfirmationPage extends Page {
+  constructor() {
+    super('Booking extension complete')
+  }
+
+  static visit(premisesId: string, bookingId: string): BookingExtensionConfirmationPage {
+    cy.visit(`/premises/${premisesId}/bookings/${bookingId}/extensions/confirmation`)
+    return new BookingExtensionConfirmationPage()
+  }
+
+  verifyBookingIsVisible(booking: Booking): void {
+    cy.get('dl').within(() => {
+      this.assertDefinition('Name', booking.name)
+      this.assertDefinition('CRN', booking.crn)
+      this.assertDefinition('Expected arrival date', formatDate(parseISO(booking.expectedArrivalDate)))
+      this.assertDefinition('New expected departure date', formatDate(parseISO(booking.expectedDepartureDate)))
+      this.assertDefinition('Key worker', booking.keyWorker.name)
+    })
+  }
+}

--- a/integration_tests/pages/booking/extension/create.ts
+++ b/integration_tests/pages/booking/extension/create.ts
@@ -1,0 +1,38 @@
+import Page, { PageElement } from '../../page'
+
+export default class BookingExtensionCreatePage extends Page {
+  constructor() {
+    super('Extend booking')
+  }
+
+  static visit(premisesId: string, bookingId: string): BookingExtensionCreatePage {
+    cy.visit(`/premises/${premisesId}/bookings/${bookingId}/extensions/new`)
+    return new BookingExtensionCreatePage()
+  }
+
+  newDepartureDay(): PageElement {
+    return cy.get('#newDepartureDate-day')
+  }
+
+  newDepartureMonth(): PageElement {
+    return cy.get('#newDepartureDate-month')
+  }
+
+  newDepartureYear(): PageElement {
+    return cy.get('#newDepartureDate-year')
+  }
+
+  clickSubmit(): void {
+    cy.get('button').click()
+  }
+
+  completeForm(newDepartureDate: string): void {
+    this.getLegend('What is the extended expected departure date?')
+
+    const parsedNewDepartureDate = new Date(Date.parse(newDepartureDate))
+
+    this.newDepartureDay().type(parsedNewDepartureDate.getDate().toString())
+    this.newDepartureMonth().type(`${parsedNewDepartureDate.getMonth() + 1}`)
+    this.newDepartureYear().type(parsedNewDepartureDate.getFullYear().toString())
+  }
+}

--- a/integration_tests/pages/booking/show.ts
+++ b/integration_tests/pages/booking/show.ts
@@ -1,7 +1,7 @@
 import type { Booking } from 'approved-premises'
 
-import Page from './page'
-import { formatDateString } from '../../server/utils/utils'
+import Page from '../page'
+import { formatDateString } from '../../../server/utils/utils'
 
 export default class BookingShowPage extends Page {
   constructor() {

--- a/integration_tests/pages/bookingCreate.ts
+++ b/integration_tests/pages/bookingCreate.ts
@@ -11,22 +11,6 @@ export default class BookingCreatePage extends Page {
     return new BookingCreatePage()
   }
 
-  getLabel(labelName: string): void {
-    cy.get('label').should('contain', labelName)
-  }
-
-  getLegend(legendName: string): void {
-    cy.get('legend').should('contain', legendName)
-  }
-
-  getTextInputByIdAndEnterDetails(id: string, details: string): void {
-    cy.get(`#${id}`).type(details)
-  }
-
-  getSelectInputByIdAndSelectAnEntry(id: string, entry: string): void {
-    cy.get(`#${id}`).select(entry)
-  }
-
   arrivalDay(): PageElement {
     return cy.get('#expectedArrivalDate-day')
   }

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -7,6 +7,7 @@ declare module 'approved-premises' {
   export type LostBed = schemas['LostBed']
   export type ReferenceData = schemas['ReferenceData']
   export type Cancellation = schemas['Cancellation']
+  export type BookingExtension = schemas['BookingExtension']
   export type KeyWorker = schemas['KeyWorker']
 
   export type BookingDto = Omit<Booking, 'id' | 'status' | 'arrival' | 'keyWorker'> & { keyWorkerId: string }
@@ -196,6 +197,10 @@ declare module 'approved-premises' {
       referenceNumber: string
       notes: string
       reason: ReferenceData
+    }
+    BookingExtension: {
+      newDepartureDate: string
+      notes: string
     }
   }
 }

--- a/server/controllers/bookingExtensionsController.test.ts
+++ b/server/controllers/bookingExtensionsController.test.ts
@@ -1,0 +1,145 @@
+import type { Request, Response, NextFunction } from 'express'
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
+import type { ErrorsAndUserInput } from 'approved-premises'
+import BookingService from '../services/bookingService'
+import BookingExtensionsController from './bookingExtensionsController'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../utils/validation'
+
+import bookingFactory from '../testutils/factories/booking'
+
+jest.mock('../utils/validation')
+
+describe('bookingExtensionsController', () => {
+  const token = 'SOME_TOKEN'
+
+  let request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const bookingService = createMock<BookingService>({})
+  const bookingExtensionsController = new BookingExtensionsController(bookingService)
+  const premisesId = 'premisesId'
+
+  describe('new', () => {
+    const booking = bookingFactory.build()
+
+    beforeEach(() => {
+      bookingService.getBooking.mockResolvedValue(booking)
+    })
+
+    it('should render the form', async () => {
+      const requestHandler = bookingExtensionsController.new()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
+        return { errors: {}, errorSummary: [], userInput: {} }
+      })
+
+      await requestHandler({ ...request, params: { premisesId, bookingId: booking.id } }, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('bookings/extensions/new', {
+        premisesId,
+        booking,
+        errors: {},
+        errorSummary: [],
+      })
+      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premisesId, booking.id)
+    })
+
+    it('renders the form with errors and user input if an error has been sent to the flash', async () => {
+      bookingService.getBooking.mockResolvedValue(booking)
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+
+      const requestHandler = bookingExtensionsController.new()
+
+      await requestHandler({ ...request, params: { premisesId, bookingId: booking.id } }, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('bookings/extensions/new', {
+        premisesId,
+        booking,
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        ...errorsAndUserInput.userInput,
+      })
+      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premisesId, booking.id)
+    })
+  })
+
+  describe('create', () => {
+    const booking = bookingFactory.build()
+
+    it('given the expected form data, the posting of the booking is successful should redirect to the "confirmation" page', async () => {
+      bookingService.extendBooking.mockResolvedValue(booking)
+
+      const requestHandler = bookingExtensionsController.create()
+
+      request = {
+        ...request,
+        params: { premisesId, bookingId: booking.id },
+        body: {
+          'newDepartureDate-day': '01',
+          'newDepartureDate-month': '02',
+          'newDepartureDate-year': '2022',
+        },
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(bookingService.extendBooking).toHaveBeenCalledWith(token, premisesId, booking.id, {
+        ...request.body,
+        newDepartureDate: '2022-02-01T00:00:00.000Z',
+      })
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        `/premises/${premisesId}/bookings/${booking.id}/extensions/confirmation`,
+      )
+    })
+
+    it('should render the page with errors when the API returns an error', async () => {
+      bookingService.extendBooking.mockResolvedValue(booking)
+      const requestHandler = bookingExtensionsController.create()
+
+      request = {
+        ...request,
+        params: { premisesId, bookingId: booking.id },
+      }
+
+      const err = new Error()
+
+      bookingService.extendBooking.mockImplementation(() => {
+        throw err
+      })
+
+      await requestHandler(request, response, next)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        err,
+        `/premises/${premisesId}/bookings/${booking.id}/extensions/new`,
+      )
+    })
+  })
+
+  describe('confirm', () => {
+    it('renders the form with the details from the booking that is requested', async () => {
+      const booking = bookingFactory.build()
+      bookingService.getBooking.mockResolvedValue(booking)
+
+      const requestHandler = bookingExtensionsController.confirm()
+
+      request = {
+        ...request,
+        params: {
+          premisesId,
+          bookingId: booking.id,
+        },
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premisesId, booking.id)
+      expect(response.render).toHaveBeenCalledWith('bookings/extensions/confirm', { premisesId, ...booking })
+    })
+  })
+})

--- a/server/controllers/bookingExtensionsController.ts
+++ b/server/controllers/bookingExtensionsController.ts
@@ -1,0 +1,54 @@
+import type { Request, Response, RequestHandler } from 'express'
+
+import type { BookingExtension } from 'approved-premises'
+import BookingService from '../services/bookingService'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../utils/validation'
+import { convertDateAndTimeInputsToIsoString } from '../utils/utils'
+
+export default class BookingExtensionsController {
+  constructor(private readonly bookingService: BookingService) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, bookingId } = req.params
+
+      const booking = await this.bookingService.getBooking(req.user.token, premisesId, bookingId)
+      const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
+
+      return res.render('bookings/extensions/new', { premisesId, booking, errors, errorSummary, ...userInput })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, bookingId } = req.params
+
+      const bookingExtension: BookingExtension = {
+        ...req.body,
+        ...convertDateAndTimeInputsToIsoString(req.body, 'newDepartureDate'),
+      }
+
+      try {
+        const extendedBooking = await this.bookingService.extendBooking(
+          req.user.token,
+          premisesId,
+          bookingId,
+          bookingExtension,
+        )
+
+        res.redirect(`/premises/${premisesId}/bookings/${extendedBooking.id}/extensions/confirmation`)
+      } catch (err) {
+        catchValidationErrorOrPropogate(req, res, err, `/premises/${premisesId}/bookings/${bookingId}/extensions/new`)
+      }
+    }
+  }
+
+  confirm(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, bookingId } = req.params
+      const booking = await this.bookingService.getBooking(req.user.token, premisesId, bookingId)
+
+      return res.render('bookings/extensions/confirm', { premisesId, ...booking })
+    }
+  }
+}

--- a/server/controllers/bookingsController.test.ts
+++ b/server/controllers/bookingsController.test.ts
@@ -80,7 +80,7 @@ describe('bookingsController', () => {
   })
 
   describe('create', () => {
-    it('given the expected form data, the posting of the booking is successful should redirect to the "premises" page', async () => {
+    it('given the expected form data, the posting of the booking is successful should redirect to the "confirmation" page', async () => {
       const booking = bookingFactory.build()
       bookingService.postBooking.mockResolvedValue(booking)
       const premisesId = 'premisesId'

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -3,6 +3,7 @@
 import ApplicationController from './applicationController'
 import PremisesController from './premisesController'
 import BookingsController from './bookingsController'
+import BookingExtensionsController from './bookingExtensionsController'
 import ArrivalsController from './arrivalsController'
 import NonArrivalsController from './nonArrivalsController'
 import DeparturesController from './departuresController'
@@ -15,6 +16,7 @@ export const controllers = (services: Services) => {
   const applicationController = new ApplicationController()
   const premisesController = new PremisesController(services.premisesService, services.bookingService)
   const bookingsController = new BookingsController(services.bookingService)
+  const bookingExtensionsController = new BookingExtensionsController(services.bookingService)
   const arrivalsController = new ArrivalsController(services.arrivalService)
   const nonArrivalsController = new NonArrivalsController(services.nonArrivalService)
   const departuresController = new DeparturesController(
@@ -29,6 +31,7 @@ export const controllers = (services: Services) => {
     applicationController,
     premisesController,
     bookingsController,
+    bookingExtensionsController,
     arrivalsController,
     nonArrivalsController,
     departuresController,
@@ -42,8 +45,8 @@ export type Controllers = ReturnType<typeof controllers>
 export {
   PremisesController,
   BookingsController,
+  BookingExtensionsController,
   ArrivalsController,
   NonArrivalsController,
   DeparturesController,
-  LostBedsController,
 }

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -80,4 +80,27 @@ describe('BookingClient', () => {
       expect(nock.isDone()).toBeTruthy()
     })
   })
+
+  describe('extendBooking', () => {
+    it('should return the booking that has been extended', async () => {
+      const booking = bookingFactory.build()
+      const payload = {
+        newDepartureDate: new Date(2042, 13, 11).toISOString(),
+        'newDepartureDate-year': '2042',
+        'newDepartureDate-month': '12',
+        'newDepartureDate-day': '11',
+        notes: 'Some notes',
+      }
+
+      fakeApprovedPremisesApi
+        .post(`/premises/premisesId/bookings/${booking.id}/extensions`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, booking)
+
+      const result = await bookingClient.extendBooking('premisesId', booking.id, payload)
+
+      expect(result).toEqual(booking)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
 })

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -1,4 +1,4 @@
-import type { Booking, BookingDto } from 'approved-premises'
+import type { Booking, BookingDto, BookingExtension } from 'approved-premises'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 
@@ -19,5 +19,12 @@ export default class BookingClient {
 
   async allBookingsForPremisesId(premisesId: string): Promise<Array<Booking>> {
     return (await this.restClient.get({ path: `/premises/${premisesId}/bookings` })) as Array<Booking>
+  }
+
+  async extendBooking(premisesId: string, bookingId: string, bookingExtension: BookingExtension): Promise<Booking> {
+    return (await this.restClient.post({
+      path: `/premises/${premisesId}/bookings/${bookingId}/extensions`,
+      data: bookingExtension,
+    })) as Booking
   }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -25,6 +25,7 @@
   },
   "moveOnCategory": { "blank": "You must enter a move on category" },
   "destinationProvider": { "blank": "You must enter a destination provider" },
+  "newDepartureDate": { "blank": "You must enter a new departure date" },
   "startDate": { "blank": "You must enter a start date" },
   "endDate": { "blank": "You must enter a end date" },
   "numberOfBeds": { "blank": "You must enter the number of beds lost" },

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -12,6 +12,7 @@ export default function routes(controllers: Controllers): Router {
     applicationController,
     premisesController,
     bookingsController,
+    bookingExtensionsController,
     arrivalsController,
     nonArrivalsController,
     departuresController,
@@ -31,6 +32,10 @@ export default function routes(controllers: Controllers): Router {
   get('/premises/:premisesId/bookings/:bookingId', bookingsController.show())
   post('/premises/:premisesId/bookings', bookingsController.create())
   get('/premises/:premisesId/bookings/:bookingId/confirmation', bookingsController.confirm())
+
+  get('/premises/:premisesId/bookings/:bookingId/extensions/new', bookingExtensionsController.new())
+  post('/premises/:premisesId/bookings/:bookingId/extensions', bookingExtensionsController.create())
+  get('/premises/:premisesId/bookings/:bookingId/extensions/confirmation', bookingExtensionsController.confirm())
 
   get('/premises/:premisesId/bookings/:bookingId/arrivals/new', arrivalsController.new())
   post('/premises/:premisesId/bookings/:bookingId/arrivals', arrivalsController.create())

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -115,6 +115,26 @@ describe('BookingService', () => {
     })
   })
 
+  describe('extendBooking', () => {
+    it('on success returns the booking that has been extended', async () => {
+      const booking = bookingFactory.build()
+      bookingClient.extendBooking.mockResolvedValue(booking)
+      const newDepartureDateObj = {
+        newDepartureDate: new Date(2042, 13, 11).toISOString(),
+        'newDepartureDate-year': '2042',
+        'newDepartureDate-month': '12',
+        'newDepartureDate-day': '11',
+        notes: 'Some notes',
+      }
+
+      const extendedBooking = await service.extendBooking(token, 'premisesId', booking.id, newDepartureDateObj)
+
+      expect(extendedBooking).toEqual(booking)
+      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClient.extendBooking).toHaveBeenCalledWith('premisesId', booking.id, newDepartureDateObj)
+    })
+  })
+
   describe('bookingsToTableRows', () => {
     it('should convert bookings to table rows with an arrival date', () => {
       const premisesId = 'some-uuid'

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -53,60 +53,6 @@ describe('BookingService', () => {
     })
   })
 
-  describe('bookingsToTableRows', () => {
-    it('should convert bookings to table rows with an arrival date', () => {
-      const premisesId = 'some-uuid'
-
-      const booking1Date = new Date(2022, 10, 22)
-      const booking2Date = new Date(2022, 2, 11)
-
-      const bookings = [
-        bookingFactory.build({ expectedArrivalDate: booking1Date.toISOString() }),
-        bookingFactory.build({ expectedArrivalDate: booking2Date.toISOString() }),
-      ]
-
-      const results = service.bookingsToTableRows(bookings, premisesId, 'arrival')
-
-      expect(results[0][0]).toEqual({ text: bookings[0].crn })
-      expect(results[0][1]).toEqual({ text: formatDate(booking1Date) })
-      expect(results[0][2]).toEqual({
-        html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[0].id}`),
-      })
-
-      expect(results[1][0]).toEqual({ text: bookings[1].crn })
-      expect(results[1][1]).toEqual({ text: formatDate(booking2Date) })
-      expect(results[1][2]).toEqual({
-        html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[1].id}`),
-      })
-    })
-
-    it('should convert bookings to table rows with a departure date', () => {
-      const premisesId = 'some-uuid'
-
-      const booking1Date = new Date(2022, 10, 22)
-      const booking2Date = new Date(2022, 2, 11)
-
-      const bookings = [
-        bookingFactory.build({ expectedDepartureDate: booking1Date.toISOString() }),
-        bookingFactory.build({ expectedDepartureDate: booking2Date.toISOString() }),
-      ]
-
-      const results = service.bookingsToTableRows(bookings, premisesId, 'departure')
-
-      expect(results[0][0]).toEqual({ text: bookings[0].crn })
-      expect(results[0][1]).toEqual({ text: formatDate(booking1Date) })
-      expect(results[0][2]).toEqual({
-        html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[0].id}`),
-      })
-
-      expect(results[1][0]).toEqual({ text: bookings[1].crn })
-      expect(results[1][1]).toEqual({ text: formatDate(booking2Date) })
-      expect(results[1][2]).toEqual({
-        html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[1].id}`),
-      })
-    })
-  })
-
   describe('listOfBookingsForPremisesId', () => {
     it('should return table rows of bookings', async () => {
       const premisesId = 'some-uuid'
@@ -168,6 +114,61 @@ describe('BookingService', () => {
       expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
     })
   })
+
+  describe('bookingsToTableRows', () => {
+    it('should convert bookings to table rows with an arrival date', () => {
+      const premisesId = 'some-uuid'
+
+      const booking1Date = new Date(2022, 10, 22)
+      const booking2Date = new Date(2022, 2, 11)
+
+      const bookings = [
+        bookingFactory.build({ expectedArrivalDate: booking1Date.toISOString() }),
+        bookingFactory.build({ expectedArrivalDate: booking2Date.toISOString() }),
+      ]
+
+      const results = service.bookingsToTableRows(bookings, premisesId, 'arrival')
+
+      expect(results[0][0]).toEqual({ text: bookings[0].crn })
+      expect(results[0][1]).toEqual({ text: formatDate(booking1Date) })
+      expect(results[0][2]).toEqual({
+        html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[0].id}`),
+      })
+
+      expect(results[1][0]).toEqual({ text: bookings[1].crn })
+      expect(results[1][1]).toEqual({ text: formatDate(booking2Date) })
+      expect(results[1][2]).toEqual({
+        html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[1].id}`),
+      })
+    })
+
+    it('should convert bookings to table rows with a departure date', () => {
+      const premisesId = 'some-uuid'
+
+      const booking1Date = new Date(2022, 10, 22)
+      const booking2Date = new Date(2022, 2, 11)
+
+      const bookings = [
+        bookingFactory.build({ expectedDepartureDate: booking1Date.toISOString() }),
+        bookingFactory.build({ expectedDepartureDate: booking2Date.toISOString() }),
+      ]
+
+      const results = service.bookingsToTableRows(bookings, premisesId, 'departure')
+
+      expect(results[0][0]).toEqual({ text: bookings[0].crn })
+      expect(results[0][1]).toEqual({ text: formatDate(booking1Date) })
+      expect(results[0][2]).toEqual({
+        html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[0].id}`),
+      })
+
+      expect(results[1][0]).toEqual({ text: bookings[1].crn })
+      expect(results[1][1]).toEqual({ text: formatDate(booking2Date) })
+      expect(results[1][2]).toEqual({
+        html: expect.stringMatching(`/premises/${premisesId}/bookings/${bookings[1].id}`),
+      })
+    })
+  })
+
   describe('currentResidents', () => {
     it('should return table rows of the current residents', async () => {
       const bookingsArrivingToday = bookingFactory.arrivingToday().buildList(2)

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -1,6 +1,6 @@
 import { isSameDay, isWithinInterval, addDays } from 'date-fns'
 
-import type { Booking, BookingDto, TableRow, GroupedListofBookings } from 'approved-premises'
+import type { Booking, BookingDto, TableRow, GroupedListofBookings, BookingExtension } from 'approved-premises'
 
 import type { RestClientBuilder } from '../data'
 import BookingClient from '../data/bookingClient'
@@ -47,6 +47,19 @@ export default class BookingService {
       upcomingArrivals: this.bookingsToTableRows(this.upcomingArrivals(bookings, today), premisesId, 'arrival'),
       upcomingDepartures: this.bookingsToTableRows(this.upcomingDepartures(bookings, today), premisesId, 'departure'),
     }
+  }
+
+  async extendBooking(
+    token: string,
+    premisesId: string,
+    bookingId: string,
+    bookingExtension: BookingExtension,
+  ): Promise<Booking> {
+    const bookingClient = this.bookingClientFactory(token)
+
+    const confirmedBooking = await bookingClient.extendBooking(premisesId, bookingId, bookingExtension)
+
+    return confirmedBooking
   }
 
   bookingsToTableRows(bookings: Array<Booking>, premisesId: string, type: 'arrival' | 'departure'): Array<TableRow> {

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -30,6 +30,11 @@ describe('bookingUtils', () => {
               text: 'Mark as not arrived',
             },
             {
+              text: 'Extend booking',
+              classes: 'govuk-button--secondary',
+              href: `/premises/premisesId/bookings/${booking.id}/extensions/new`,
+            },
+            {
               classes: 'govuk-button--secondary',
               href: `/premises/premisesId/bookings/${booking.id}/cancellations/new`,
               text: 'Cancel booking',
@@ -49,6 +54,11 @@ describe('bookingUtils', () => {
               classes: 'govuk-button--secondary',
               href: `/premises/premisesId/bookings/${booking.id}/departures/new`,
               text: 'Log departure',
+            },
+            {
+              text: 'Extend booking',
+              classes: 'govuk-button--secondary',
+              href: `/premises/premisesId/bookings/${booking.id}/extensions/new`,
             },
             {
               classes: 'govuk-button--secondary',

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -16,6 +16,11 @@ export default function bookingActions(booking: Booking, premisesId: string): Ar
         href: `/premises/${premisesId}/bookings/${booking.id}/arrivals/new`,
       })
       items.push({
+        text: 'Extend booking',
+        classes: 'govuk-button--secondary',
+        href: `/premises/${premisesId}/bookings/${booking.id}/extensions/new`,
+      })
+      items.push({
         text: 'Cancel booking',
         classes: 'govuk-button--secondary',
         href: `/premises/${premisesId}/bookings/${booking.id}/cancellations/new`,
@@ -27,6 +32,11 @@ export default function bookingActions(booking: Booking, premisesId: string): Ar
         text: 'Log departure',
         classes: 'govuk-button--secondary',
         href: `/premises/${premisesId}/bookings/${booking.id}/departures/new`,
+      })
+      items.push({
+        text: 'Extend booking',
+        classes: 'govuk-button--secondary',
+        href: `/premises/${premisesId}/bookings/${booking.id}/extensions/new`,
       })
       items.push({
         text: 'Cancel booking',

--- a/server/views/bookings/extensions/confirm.njk
+++ b/server/views/bookings/extensions/confirm.njk
@@ -1,0 +1,65 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Extension confirmed" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ govukPanel({
+            titleText: "Booking extension complete"
+            }) }}
+            {{ govukSummaryList({
+                rows: [
+                   {
+                    key: {
+                        text: "Name"
+                    },
+                    value: {
+                        text: name
+                    }
+                    },
+                    {
+                    key: {
+                        text: "CRN"
+                    },
+                    value: {
+                        text: crn
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Expected arrival date"
+                    },
+                    value: {
+                        text: formatDate(expectedArrivalDate)
+                    }
+                    },
+                    {
+                    key: {
+                        text: "New expected departure date"
+                    },
+                    value: {
+                        text: formatDate(expectedDepartureDate)
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Key worker"
+                    },
+                    value: {
+                        text: keyWorker.name
+                    }
+                    }
+                ]
+            }) }}
+
+            <p class="govuk-body">
+                <a href="/premises/" + premisesId + "/bookings/" + bookingId>Back to dashboard</a>
+            </p>
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/bookings/extensions/new.njk
+++ b/server/views/bookings/extensions/new.njk
@@ -1,0 +1,91 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Extend booking" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+    {{ govukBackLink({
+		text: "Back",
+		href: "/premises/" + premisesId + "/bookings/" + booking.id
+	}) }}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="/premises/{{premisesId}}/bookings/{{booking.id}}/extensions" method="post">
+
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+                <h1>Extend booking</h1>
+
+                {{ govukSummaryList({
+                rows: [
+                   {
+                    key: {
+                        text: "Name"
+                    },
+                    value: {
+                        text: booking.name
+                    }
+                    },
+                    {
+                    key: {
+                        text: "CRN"
+                    },
+                    value: {
+                        text: booking.crn
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Expected arrival date"
+                    },
+                    value: {
+                        text: formatDate(booking.expectedArrivalDate)
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Current expected departure date"
+                    },
+                    value: {
+                        text: formatDate(booking.expectedDepartureDate)
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Key worker"
+                    },
+                    value: {
+                        text: booking.keyWorker.name
+                    }
+                    }
+                ]
+            }) }}
+                {{ showErrorSummary(errorSummary) }}
+
+                {{ govukDateInput({
+                    id: "newDepartureDate",
+                    namePrefix: "newDepartureDate",
+                    fieldset: {
+                    legend: {
+                        text: "What is the extended expected departure date?",
+                        classes: "govuk-fieldset__legend--m"
+                        }
+                    },
+                    hint: {
+                    text: "For example, 27 3 2007"
+                    },
+                    items: dateFieldValues('newDepartureDate', errors),
+                    errorMessage: errors.newDepartureDate  
+                }) }}
+
+                {{ govukButton({
+                    text: "Submit"
+                }) }}
+            </div>
+        </div>
+    {% endblock %}

--- a/wiremock/bookingExtensionStubs.ts
+++ b/wiremock/bookingExtensionStubs.ts
@@ -1,0 +1,27 @@
+import { guidRegex } from './index'
+import bookingDtoFactory from '../server/testutils/factories/bookingDto'
+import { errorStub } from './utils'
+
+export default [
+  {
+    priority: 99,
+    request: {
+      method: 'POST',
+      urlPathPattern: `/premises/${guidRegex}/bookings/${guidRegex}/extensions`,
+      bodyPatterns: [
+        {
+          matchesJsonPath: "$.[?(@.newDepartureDate != '')]",
+        },
+      ],
+    },
+    response: {
+      status: 201,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: bookingDtoFactory.build(),
+    },
+  },
+
+  errorStub(['newDepartureDate'], `/premises/${guidRegex}/bookings/${guidRegex}/extensions`),
+]

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -9,6 +9,7 @@ import bookingFactory from '../server/testutils/factories/booking'
 import premisesFactory from '../server/testutils/factories/premises'
 
 import bookingStubs from './bookingStubs'
+import boookingExtensionStubs from './bookingExtensionStubs'
 import arrivalStubs from './arrivalStubs'
 import nonArrivalStubs from './nonArrivalStubs'
 import departureStubs from './departuresStubs'
@@ -99,6 +100,7 @@ stubs.push(
   ...nonArrivalStubs,
   ...departureStubs,
   ...cancellationStubs,
+  ...boookingExtensionStubs,
   ...lostBedStubs,
   ...Object.values(referenceDataStubs),
 )


### PR DESCRIPTION
# Context
AP Managers need to be able to extend a booking if neccessary. 
https://trello.com/c/M2MH0WYC/537-extensions-of-bookings

# Changes in this PR
From the booking details screen I have added an 'action' that allows the users to extend a booking by entering a new departure date. 
To post this data to the backend we use the BookingClient and BookingService but I have created a new BookingExtensionsController.
Once the extension has been posted successfully the user is presented with a confirmation screen which lets them know the action has been successful. 

## Screenshots of UI changes

### After
![image](https://user-images.githubusercontent.com/44123869/186880389-95bd04cb-5009-49a5-9bc3-a93c8987d93d.png)
![image](https://user-images.githubusercontent.com/44123869/186881355-5d1944e7-1d27-4396-98a4-8f5b3cc192fc.png)
![image](https://user-images.githubusercontent.com/44123869/186881958-fd99b4a1-ee7a-4af2-99f7-bb56db64fc03.png)

