### PR TITLE
Success messages for arrivals and non arrivals

### DIFF
--- a/integration_tests/e2e/arrivals.cy.ts
+++ b/integration_tests/e2e/arrivals.cy.ts
@@ -44,7 +44,8 @@ context('Arrivals', () => {
     })
 
     // And I should be redirected to the premises page
-    PremisesShowPage.verifyOnPage(PremisesShowPage, premises)
+    const premisesPage = PremisesShowPage.verifyOnPage(PremisesShowPage, premises)
+    premisesPage.shouldShowBanner('Arrival logged')
   })
 
   it('show arrival errors when the API returns an error', () => {
@@ -102,7 +103,8 @@ context('Arrivals', () => {
     })
 
     // And I should be redirected to the premises page
-    PremisesShowPage.verifyOnPage(PremisesShowPage, premises)
+    const premisesPage = PremisesShowPage.verifyOnPage(PremisesShowPage, premises)
+    premisesPage.shouldShowBanner('Non-arrival logged')
   })
 
   it('show non-arrival errors when the API returns an error', () => {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -34,6 +34,10 @@ export default abstract class Page {
     })
   }
 
+  shouldShowBanner(copy: string): void {
+    cy.get('.govuk-notification-banner').contains(copy)
+  }
+
   getLabel(labelName: string): void {
     cy.get('label').should('contain', labelName)
   }

--- a/server/app.ts
+++ b/server/app.ts
@@ -45,6 +45,7 @@ export default function createApp(controllers: Controllers, services: Services):
   app.use(setUpCurrentUser(services))
   app.use((req, res, next) => {
     res.app.locals.infoMessages = req.flash('info')
+    res.app.locals.successMessages = req.flash('success')
     return next()
   })
   app.use(routes(controllers))

--- a/server/controllers/arrivalsController.test.ts
+++ b/server/controllers/arrivalsController.test.ts
@@ -98,6 +98,7 @@ describe('ArrivalsController', () => {
         expectedArrival,
       )
 
+      expect(request.flash).toHaveBeenCalledWith('success', 'Arrival logged')
       expect(response.redirect).toHaveBeenCalledWith(`/premises/${request.params.premisesId}`)
     })
 

--- a/server/controllers/arrivalsController.ts
+++ b/server/controllers/arrivalsController.ts
@@ -41,6 +41,7 @@ export default class ArrivalsController {
       try {
         await this.arrivalService.createArrival(req.user.token, premisesId, bookingId, arrival)
 
+        req.flash('success', 'Arrival logged')
         res.redirect(`/premises/${premisesId}`)
       } catch (err) {
         catchValidationErrorOrPropogate(req, res, err, `/premises/${premisesId}/bookings/${bookingId}/arrivals/new`)

--- a/server/controllers/nonArrivalsController.test.ts
+++ b/server/controllers/nonArrivalsController.test.ts
@@ -42,6 +42,7 @@ describe('NonArrivalsController', () => {
 
       expect(response.redirect).toHaveBeenCalledWith(`/premises/${request.params.premisesId}`)
 
+      expect(request.flash).toHaveBeenCalledWith('success', 'Non-arrival logged')
       expect(nonArrivalService.createNonArrival).toHaveBeenCalledWith(
         token,
         request.params.premisesId,

--- a/server/controllers/nonArrivalsController.ts
+++ b/server/controllers/nonArrivalsController.ts
@@ -21,6 +21,7 @@ export default class NonArrivalsController {
       try {
         await this.nonArrivalService.createNonArrival(req.user.token, premisesId, bookingId, nonArrival)
 
+        req.flash('success', 'Non-arrival logged')
         res.redirect(`/premises/${premisesId}`)
       } catch (err) {
         catchValidationErrorOrPropogate(req, res, err, `/premises/${premisesId}/bookings/${bookingId}/arrivals/new`)

--- a/server/views/_messages.njk
+++ b/server/views/_messages.njk
@@ -8,3 +8,12 @@
     }) }}
   {% endfor %}
 {% endif %}
+
+{% if successMessages %}
+  {% for message in successMessages %}
+    {{ govukNotificationBanner({
+      html: '<h3 class="govuk-!-margin-top-2">' + message + '</h3>',
+      type: 'success'
+    }) }}
+  {% endfor %}
+{% endif %}

--- a/server/views/premises/show.njk
+++ b/server/views/premises/show.njk
@@ -1,3 +1,4 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
@@ -15,6 +16,8 @@
 		text: "Back",
 		href: "/premises"
 	}) }}
+
+  {% include "../_messages.njk" %}
 
   <h1>{{ premises.name }}</h1>
 


### PR DESCRIPTION
We currently don't give the user any feedback when they sucessfully mark someone as having arrived or non-arrived which could create confusion.
A confirmation screen seemed like a step too far for a small action so we just show a flash message on the Premises detail page for now.

![image](https://user-images.githubusercontent.com/44123869/186944721-69ccb831-ec3d-425e-b7c3-39d6218fecd8.png)
![image](https://user-images.githubusercontent.com/44123869/186944777-182f639a-e0ea-4c57-a805-8cbd52af1c07.png)
