### PR TITLE
Use identity bar to show actions on premises page

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -6,3 +6,5 @@ $path: "/assets/images/"
 
 @import './components/header-bar'
 @import './local'
+
+@import './pages/premises/show'

--- a/assets/sass/pages/premises/show.scss
+++ b/assets/sass/pages/premises/show.scss
@@ -1,0 +1,18 @@
+.premises-show {
+  .moj-identity-bar {
+    margin: 0.8em 0 2em;
+
+    &__details {
+      padding: 0;
+      margin: 0;
+    }
+
+    &__title {
+      h1 {
+        display: inline;
+        margin: 0;
+        padding: 0;
+      }
+    }
+  }
+}

--- a/server/views/premises/show.njk
+++ b/server/views/premises/show.njk
@@ -6,10 +6,13 @@
 {% from "../bookings/_table.njk" import bookingTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - " + premises.name %}
 {% set mainClasses = "app-container govuk-body" %}
+{% set bodyClasses = "premises-show" %}
 
 {% block content %}
 
@@ -20,7 +23,22 @@
 
   {% include "../_messages.njk" %}
 
-  <h1>{{ premises.name }}</h1>
+  {{ mojIdentityBar({
+      title: {
+        html: "<h1>" + premises.name + "</h1>"
+      },
+      menus: [{
+        items: [{
+          text: "Create a booking",
+          classes: "govuk-button--secondary",
+          href: paths.bookings.new({premisesId: premisesId})
+        }, {
+          text: "Record a lost bed",
+          classes: "govuk-button--secondary",
+          href: paths.lostBeds.new({premisesId: premisesId})
+        }]
+      }]
+    }) }}
 
   {{
 		govukSummaryList(premises.summaryList)
@@ -81,12 +99,10 @@
     rows: currentResidents
   }) }}
 
-  <h2>Log a lost bed</h2>
+{% endblock %}
 
-  {{ govukButton({
-            text: "Log",
-            type: 'button',
-            href: paths.lostBeds.new({premisesId: premisesId})
-        }) }}
-
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+    new MOJFrontend.ButtonMenu({container: $('.moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Actions", menuClasses: "moj-button-menu__wrapper--right"});
+  </script>
 {% endblock %}


### PR DESCRIPTION
We don’t have a way of creating a new booking at the moment, and this groups the actions more nicely at the top of the page. This may need some design input when @beth-dixxon gets back, but will do for now

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/109774/187847008-4b13c7fc-2008-4354-9c05-fc155229b86f.png)

## After

![image](https://user-images.githubusercontent.com/109774/187846965-6078c165-ba5e-4c26-ae88-1c1f1d61543e.png)
