### PR TITLE
(598) Update new booking to search by crn

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -10,6 +10,7 @@ import nonArrival from './integration_tests/mockApis/nonArrival'
 import departure from './integration_tests/mockApis/departure'
 import cancellation from './integration_tests/mockApis/cancellation'
 import lostBed from './integration_tests/mockApis/lostBed'
+import person from './integration_tests/mockApis/person'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -36,6 +37,7 @@ export default defineConfig({
         ...departure,
         ...cancellation,
         ...lostBed,
+        ...person,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -1,0 +1,30 @@
+import { SuperAgentRequest } from 'superagent'
+
+import type { Person } from 'approved-premises'
+
+import { stubFor, getMatchingRequests } from '../../wiremock'
+import { errorStub } from '../../wiremock/utils'
+
+export default {
+  stubFindPerson: (args: { person: Person }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: '/people/search',
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.person,
+      },
+    }),
+  stubFindPersonErrors: (args: { params: Array<string> }): SuperAgentRequest =>
+    stubFor(errorStub(args.params, '/people/search')),
+  verifyFindPerson: async () =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: '/people/search',
+      })
+    ).body.requests,
+}

--- a/integration_tests/pages/booking/find.ts
+++ b/integration_tests/pages/booking/find.ts
@@ -1,0 +1,27 @@
+import Page from '../page'
+import paths from '../../../server/paths/manage'
+
+export default class BookingFindPage extends Page {
+  constructor() {
+    super('Make a booking')
+  }
+
+  static visit(premisesId: string): BookingFindPage {
+    cy.visit(paths.bookings.new({ premisesId }))
+    return new BookingFindPage()
+  }
+
+  enterCrn(crn: string): void {
+    this.getLabel('Find someone by CRN')
+    this.getTextInputByIdAndEnterDetails('crn', crn)
+  }
+
+  clickSubmit(): void {
+    cy.get('button').click()
+  }
+
+  completeForm(crn: string): void {
+    this.enterCrn(crn)
+    this.clickSubmit()
+  }
+}

--- a/integration_tests/pages/booking/new.ts
+++ b/integration_tests/pages/booking/new.ts
@@ -1,16 +1,23 @@
-import type { Booking } from 'approved-premises'
+import type { Booking, Person } from 'approved-premises'
 import Page, { PageElement } from '../page'
 import paths from '../../../server/paths/manage'
 
-export default class BookingCreatePage extends Page {
+export default class BookingNewPage extends Page {
   constructor() {
     super('Make a booking')
   }
 
-  static visit(premisesId: string): BookingCreatePage {
+  static visit(premisesId: string): BookingNewPage {
     cy.visit(paths.bookings.new({ premisesId }))
 
-    return new BookingCreatePage()
+    return new BookingNewPage()
+  }
+
+  verifyPersonIsVisible(person: Person): void {
+    cy.get('dl').within(() => {
+      this.assertDefinition('Name', person.name)
+      this.assertDefinition('CRN', person.crn)
+    })
   }
 
   arrivalDay(): PageElement {
@@ -42,12 +49,6 @@ export default class BookingCreatePage extends Page {
   }
 
   completeForm(booking: Booking): void {
-    this.getLabel('CRN')
-    this.getTextInputByIdAndEnterDetails('crn', booking.crn)
-
-    this.getLabel('Name')
-    this.getTextInputByIdAndEnterDetails('name', booking.name)
-
     this.getLegend('What is the expected arrival date?')
 
     const expectedArrivalDate = new Date(Date.parse(booking.expectedArrivalDate))

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -9,6 +9,7 @@ declare module 'approved-premises' {
   export type Cancellation = schemas['Cancellation']
   export type BookingExtension = schemas['BookingExtension']
   export type KeyWorker = schemas['KeyWorker']
+  export type Person = schemas['Person']
   export type PremisesCapacityItem = schemas['PremisesCapacityItem']
   export type PremisesCapacity = Array<PremisesCapacityItem>
 
@@ -203,6 +204,10 @@ declare module 'approved-premises' {
     BookingExtension: {
       newDepartureDate: string
       notes: string
+    }
+    Person: {
+      crn: string
+      name: string
     }
     PremisesCapacityItem: {
       date: string

--- a/server/controllers/manage/bookingsController.test.ts
+++ b/server/controllers/manage/bookingsController.test.ts
@@ -13,6 +13,7 @@ jest.mock('../../utils/validation')
 
 describe('bookingsController', () => {
   const token = 'SOME_TOKEN'
+  const premisesId = 'premisesId'
 
   let request: DeepMocked<Request> = createMock<Request>({ user: { token } })
   const response: DeepMocked<Response> = createMock<Response>({})
@@ -28,10 +29,8 @@ describe('bookingsController', () => {
       bookingService.find.mockResolvedValue(booking)
 
       const requestHandler = bookingController.show()
-      const premisesId = 'premisesId'
-      const bookingId = 'bookingId'
 
-      await requestHandler({ ...request, params: { premisesId, bookingId } }, response, next)
+      await requestHandler({ ...request, params: { premisesId, bookingId: booking.id } }, response, next)
 
       expect(response.render).toHaveBeenCalledWith('bookings/show', {
         booking,
@@ -39,14 +38,14 @@ describe('bookingsController', () => {
         pageHeading: 'Booking details',
       })
 
-      expect(bookingService.find).toHaveBeenCalledWith(token, premisesId, bookingId)
+      expect(bookingService.find).toHaveBeenCalledWith(token, premisesId, booking.id)
     })
   })
 
   describe('new', () => {
     it('should render the form', async () => {
       const requestHandler = bookingController.new()
-      const premisesId = 'premisesId'
+
       ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
         return { errors: {}, errorSummary: [], userInput: {} }
       })
@@ -63,7 +62,6 @@ describe('bookingsController', () => {
 
     it('renders the form with errors and user input if an error has been sent to the flash', () => {
       const requestHandler = bookingController.new()
-      const premisesId = 'premisesId'
 
       const errorsAndUserInput = createMock<ErrorsAndUserInput>()
 
@@ -85,7 +83,7 @@ describe('bookingsController', () => {
     it('given the expected form data, the posting of the booking is successful should redirect to the "confirmation" page', async () => {
       const booking = bookingFactory.build()
       bookingService.create.mockResolvedValue(booking)
-      const premisesId = 'premisesId'
+
       const requestHandler = bookingController.create()
 
       request = {
@@ -121,7 +119,6 @@ describe('bookingsController', () => {
       const booking = bookingFactory.build()
       bookingService.create.mockResolvedValue(booking)
       const requestHandler = bookingController.create()
-      const premisesId = 'premisesId'
 
       request = {
         ...request,
@@ -156,7 +153,7 @@ describe('bookingsController', () => {
       const overcapacityMessage = 'The premises is over capacity for the period January 1st 2023 to Feburary 3rd 2023'
       premisesService.getOvercapacityMessage.mockResolvedValue(overcapacityMessage)
       bookingService.find.mockResolvedValue(booking)
-      const premisesId = 'premisesId'
+
       const requestHandler = bookingController.confirm()
 
       request = {

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -14,7 +14,11 @@ import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
   const premisesController = new PremisesController(services.premisesService, services.bookingService)
-  const bookingsController = new BookingsController(services.bookingService, services.premisesService)
+  const bookingsController = new BookingsController(
+    services.bookingService,
+    services.premisesService,
+    services.personService,
+  )
   const bookingExtensionsController = new BookingExtensionsController(services.bookingService)
   const arrivalsController = new ArrivalsController(services.arrivalService)
   const nonArrivalsController = new NonArrivalsController(services.nonArrivalService)

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -8,6 +8,7 @@ import NonArrivalsController from './nonArrivalsController'
 import DeparturesController from './departuresController'
 import CancellationsController from './cancellationsController'
 import LostBedsController from './lostBedsController'
+import PeopleController from '../peopleController'
 
 import type { Services } from '../../services'
 
@@ -24,6 +25,7 @@ export const controllers = (services: Services) => {
   )
   const cancellationsController = new CancellationsController(services.cancellationService, services.bookingService)
   const lostBedsController = new LostBedsController(services.lostBedService)
+  const peopleController = new PeopleController(services.personService)
 
   return {
     premisesController,
@@ -34,6 +36,7 @@ export const controllers = (services: Services) => {
     departuresController,
     cancellationsController,
     lostBedsController,
+    peopleController,
   }
 }
 
@@ -44,4 +47,5 @@ export {
   ArrivalsController,
   NonArrivalsController,
   DeparturesController,
+  PeopleController,
 }

--- a/server/controllers/peopleController.test.ts
+++ b/server/controllers/peopleController.test.ts
@@ -1,0 +1,79 @@
+import type { Request, Response, NextFunction } from 'express'
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
+import PeopleController from './peopleController'
+import PersonService from '../services/personService'
+import personFactory from '../testutils/factories/person'
+import { catchValidationErrorOrPropogate } from '../utils/validation'
+
+jest.mock('../utils/validation')
+
+describe('PeopleController', () => {
+  const token = 'SOME_TOKEN'
+  const premisesId = 'premisesId'
+
+  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const personService = createMock<PersonService>({})
+
+  let peopleController: PeopleController
+
+  beforeEach(() => {
+    peopleController = new PeopleController(personService)
+  })
+
+  describe('find', () => {
+    it('should return the person related to the CRN if they exist', async () => {
+      const person = personFactory.build()
+      personService.findByCrn.mockResolvedValue(person)
+      const flashSpy = jest.fn()
+
+      const requestHandler = peopleController.find()
+
+      await requestHandler(
+        {
+          ...request,
+          params: { premisesId },
+          body: { crn: person.crn, successUrl: 'success/', failureUrl: 'failure/' },
+          headers: {
+            referer: 'some-referrer/',
+          },
+          flash: flashSpy,
+        },
+        response,
+        next,
+      )
+
+      expect(response.redirect).toHaveBeenCalledWith('some-referrer/')
+      expect(personService.findByCrn).toHaveBeenCalledWith(token, person.crn)
+      expect(flashSpy).toHaveBeenCalledWith('crn', person.crn)
+    })
+
+    it('renders with errors if the API returns an error', async () => {
+      const requestHandler = peopleController.find()
+
+      const err = new Error()
+
+      personService.findByCrn.mockImplementation(() => {
+        throw err
+      })
+
+      await requestHandler(
+        {
+          ...request,
+          params: { premisesId },
+          body: { successUrl: 'success/', failureUrl: 'failure/' },
+          headers: {
+            referer: 'some-referrer/',
+          },
+        },
+        response,
+        next,
+      )
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, 'some-referrer/')
+    })
+  })
+})

--- a/server/controllers/peopleController.ts
+++ b/server/controllers/peopleController.ts
@@ -1,0 +1,22 @@
+import type { Request, Response, RequestHandler } from 'express'
+
+import PersonService from '../services/personService'
+import { catchValidationErrorOrPropogate } from '../utils/validation'
+
+export default class PeopleController {
+  constructor(private readonly personService: PersonService) {}
+
+  find(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { crn } = req.body
+
+      try {
+        const person = await this.personService.findByCrn(req.user.token, crn)
+        req.flash('crn', person.crn)
+        res.redirect(req.headers.referer)
+      } catch (err) {
+        catchValidationErrorOrPropogate(req, res, err, req.headers.referer)
+      }
+    }
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -14,6 +14,7 @@ buildAppInsightsClient()
 import HmppsAuthClient from './hmppsAuthClient'
 import PremisesClient from './premisesClient'
 import ReferenceDataClient from './referenceDataClient'
+import PersonClient from './personClient'
 
 import { createRedisClient } from './redisClient'
 import TokenStore from './tokenStore'
@@ -28,8 +29,17 @@ export const dataAccess = () => ({
   referenceDataClientBuilder: ((token: string) =>
     new ReferenceDataClient(token)) as RestClientBuilder<ReferenceDataClient>,
   lostBedClientBuilder: ((token: string) => new LostBedClient(token)) as RestClientBuilder<LostBedClient>,
+  personClient: ((token: string) => new PersonClient(token)) as RestClientBuilder<PersonClient>,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>
 
-export { BookingClient, PremisesClient, HmppsAuthClient, RestClientBuilder, ReferenceDataClient, LostBedClient }
+export {
+  BookingClient,
+  PremisesClient,
+  HmppsAuthClient,
+  RestClientBuilder,
+  ReferenceDataClient,
+  LostBedClient,
+  PersonClient,
+}

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -1,0 +1,43 @@
+import nock from 'nock'
+
+import PersonClient from './personClient'
+import config from '../config'
+import personFactory from '../testutils/factories/person'
+
+describe('PersonClient', () => {
+  let fakeApprovedPremisesApi: nock.Scope
+  let personClient: PersonClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    config.apis.approvedPremises.url = 'http://localhost:8080'
+    fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
+    personClient = new PersonClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('search', () => {
+    it('should return a person', async () => {
+      const person = personFactory.build()
+
+      fakeApprovedPremisesApi
+        .post(`/people/search`, { crn: 'crn' })
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, person)
+
+      const result = await personClient.search('crn')
+
+      expect(result).toEqual(person)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+})

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -1,0 +1,20 @@
+import type { Person } from 'approved-premises'
+import RestClient from './restClient'
+import config, { ApiConfig } from '../config'
+
+export default class PersonClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, token)
+  }
+
+  async search(crn: string): Promise<Person> {
+    const response = await this.restClient.post({
+      path: `/people/search`,
+      data: { crn },
+    })
+
+    return response as Person
+  }
+}

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -28,6 +28,7 @@ export default function setUpWebSecurity(): Router {
           fontSrc: ["'self'"],
         },
       },
+      referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
       crossOriginEmbedderPolicy: true,
     }),
   )

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -6,6 +6,8 @@ const singlePremisesPath = premisesPath.path(':premisesId')
 const bookingsPath = singlePremisesPath.path('bookings')
 const bookingPath = bookingsPath.path(':bookingId')
 
+const peoplePath = bookingsPath.path('people')
+
 const extensionsPath = bookingPath.path('extensions')
 
 const arrivalsPath = bookingPath.path('arrivals')
@@ -51,6 +53,9 @@ const paths = {
       create: departuresPath,
       confirm: departuresPath.path(':departureId/confirmation'),
     },
+  },
+  people: {
+    find: peoplePath,
   },
   lostBeds: {
     new: lostBedsPath.path('new'),

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -19,6 +19,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     departuresController,
     cancellationsController,
     lostBedsController,
+    peopleController,
   } = controllers
 
   get(paths.premises.index.pattern, premisesController.index())
@@ -28,6 +29,8 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(paths.bookings.show.pattern, bookingsController.show())
   post(paths.bookings.create.pattern, bookingsController.create())
   get(paths.bookings.confirm.pattern, bookingsController.confirm())
+
+  post(paths.people.find.pattern, peopleController.find())
 
   get(paths.bookings.extensions.new.pattern, bookingExtensionsController.new())
   post(paths.bookings.extensions.create.pattern, bookingExtensionsController.create())

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -4,6 +4,7 @@ import { dataAccess } from '../data'
 
 import UserService from './userService'
 import PremisesService from './premisesService'
+import PersonService from './personService'
 import BookingService from './bookingService'
 import ArrivalService from './arrivalService'
 import NonArrivalService from './nonArrivalService'
@@ -18,10 +19,12 @@ export const services = () => {
     bookingClientBuilder,
     referenceDataClientBuilder,
     lostBedClientBuilder,
+    personClient,
   } = dataAccess()
 
   const userService = new UserService(hmppsAuthClient)
   const premisesService = new PremisesService(approvedPremisesClientBuilder)
+  const personService = new PersonService(personClient)
   const bookingService = new BookingService(bookingClientBuilder)
   const arrivalService = new ArrivalService(bookingClientBuilder)
   const nonArrivalService = new NonArrivalService(bookingClientBuilder)
@@ -32,6 +35,7 @@ export const services = () => {
   return {
     userService,
     premisesService,
+    personService,
     bookingService,
     arrivalService,
     nonArrivalService,
@@ -46,6 +50,7 @@ export type Services = ReturnType<typeof services>
 export {
   UserService,
   PremisesService,
+  PersonService,
   ArrivalService,
   NonArrivalService,
   DepartureService,

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -1,0 +1,35 @@
+import type { Person } from 'approved-premises'
+
+import PersonService from './personService'
+import PersonClient from '../data/personClient'
+import PersonFactory from '../testutils/factories/person'
+
+jest.mock('../data/personClient.ts')
+
+describe('PersonService', () => {
+  const personClient = new PersonClient(null) as jest.Mocked<PersonClient>
+  const personClientFactory = jest.fn()
+
+  const service = new PersonService(personClientFactory)
+
+  const token = 'SOME_TOKEN'
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    personClientFactory.mockReturnValue(personClient)
+  })
+
+  describe('findByCrn', () => {
+    it('on success returns the person given their CRN', async () => {
+      const person: Person = PersonFactory.build()
+      personClient.search.mockResolvedValue(person)
+
+      const postedPerson = await service.findByCrn(token, 'crn')
+
+      expect(postedPerson).toEqual(person)
+
+      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClient.search).toHaveBeenCalledWith('crn')
+    })
+  })
+})

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -1,0 +1,13 @@
+import type { Person } from 'approved-premises'
+import type { RestClientBuilder, PersonClient } from '../data'
+
+export default class PersonService {
+  constructor(private readonly personClientFactory: RestClientBuilder<PersonClient>) {}
+
+  async findByCrn(token: string, crn: string): Promise<Person> {
+    const personClient = this.personClientFactory(token)
+
+    const person = await personClient.search(crn)
+    return person
+  }
+}

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -1,0 +1,9 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { Person } from 'approved-premises'
+
+export default Factory.define<Person>(() => ({
+  crn: faker.datatype.uuid(),
+  name: faker.name.fullName(),
+}))

--- a/server/views/bookings/find.njk
+++ b/server/views/bookings/find.njk
@@ -1,0 +1,39 @@
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../partials/showErrorSummary.njk" import showErrorSummary %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1>Make a booking</h1>
+            <form action="{{ paths.people.find({ premisesId: premisesId }) }}" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+                {{ showErrorSummary(errorSummary) }}
+
+                {{ govukInput({
+                    label: {
+                        text: "Find someone by CRN",
+                        classes: "govuk-label--m"
+                    },
+                    classes: "govuk-input--width-10",
+                    id: "crn",
+                    name: "crn",
+                    value: crn,
+                    errorMessage: errors.crn
+                    }) }}
+
+                {{ govukButton({
+                    name: 'arrival[submit]',
+                    text: "Submit"
+                }) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/bookings/new.njk
+++ b/server/views/bookings/new.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
@@ -23,30 +24,29 @@
         <div class="govuk-grid-column-two-thirds">
             <form action="{{ paths.bookings.create({ premisesId: premisesId }) }}" method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+                <input type="hidden" name="crn" value="{{ crn }}"/>
 
                 {{ showErrorSummary(errorSummary) }}
 
-                {{ govukInput({
-                    label: {
-                        text: "CRN",
-                        classes: "govuk-label--m"
+                {{ govukSummaryList({
+                rows: [
+                   {
+                    key: {
+                        text: "Name"
                     },
-                    classes: "govuk-input--width-10",
-                    id: "crn",
-                    name: "crn",
-                    value: crn,
-                    errorMessage: errors.crn
-                }) }}
-
-                {{ govukInput({
-                    label: {
-                        text: "Name",
-                        classes: "govuk-label--m"
+                    value: {
+                        text: name
+                    }
                     },
-                    classes: "govuk-input--width-10",
-                    id: "name",
-                    name: "name",
-                    errorMessage: errors.name
+                    {
+                    key: {
+                        text: "CRN"
+                    },
+                    value: {
+                        text: crn
+                    }
+                    }
+                ]
                 }) }}
 
                 {{ govukDateInput({

--- a/server/views/departures/confirm.njk
+++ b/server/views/departures/confirm.njk
@@ -1,6 +1,5 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% extends "../partials/layout.njk" %}
 

--- a/wiremock/personStubs.ts
+++ b/wiremock/personStubs.ts
@@ -1,0 +1,23 @@
+import personFactory from '../server/testutils/factories/person'
+import { errorStub } from './utils'
+
+const personStubs: Array<Record<string, unknown>> = []
+
+personStubs.push({
+  priority: 99,
+  request: {
+    method: 'POST',
+    urlPathPattern: `/people/search`,
+  },
+  response: {
+    status: 201,
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+    },
+    jsonBody: personFactory.build(),
+  },
+})
+
+personStubs.push(errorStub(['crn'], `people/search`))
+
+export default personStubs

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -15,6 +15,7 @@ import nonArrivalStubs from './nonArrivalStubs'
 import departureStubs from './departuresStubs'
 import cancellationStubs from './cancellationStubs'
 import lostBedStubs from './lostBedStubs'
+import personStubs from './personStubs'
 
 import * as referenceDataStubs from './referenceDataStubs'
 import premisesCapacityItemFactory from '../server/testutils/factories/premisesCapacityItem'
@@ -117,6 +118,7 @@ stubs.push(
   ...cancellationStubs,
   ...boookingExtensionStubs,
   ...lostBedStubs,
+  ...personStubs,
   ...Object.values(referenceDataStubs),
 )
 


### PR DESCRIPTION
## Context

AP Managers need to be able to create a booking for a person and be assured that the booking has been created for the correct person. Our service also needs to ensure that we know exactly who the person the booking has been created for. 
People in prison/probation are tracked by a UUID - their 'CRN', so we need AP managers to enter this when creating a booking. To ensure they have entered the correct CRN they need to be presented with the name of the person that CRN relates to when creating a booking.

This will neccessitate us calling our API with a CRN which is something we will also need to do for the 'Apply' stage of the Approved Premises service so this feature has been built with this in mind.

[Trello ticket](https://trello.com/c/GeIvVkOn/598-update-create-booking-to-search-by-crn)

## Journey changes in this PR

Making a booking was previously a 2 step process: 
1. The user entered the details of the booking in a form 
2. they were then presented with confirmation of the booking.

Making a booking is now a 3 step process: 
1. The user enters a CRN
2. they are then presented with a page which shows the CRN just entered and the name related to that CRN at the top. The rest of the form is identical to the one from step 1 of the previous process.
3. The user is presented with confirmation of their booking.

## Code Changes 

I have added a new controller - the people controller - to post the CRN to our API. 
The booking controller now has two methods for the form 'find' for searching by CRN and 'new' for the rest of the booking. I'm not entirely set on these names (or any of the naming tbh) so feedback encouraged.

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/44123869/188171119-a57df490-67d9-4414-a4c4-e825c8d36cfe.png)

### After
![image](https://user-images.githubusercontent.com/44123869/188866460-29e885e6-98de-4a8d-a5f2-fea5d24ea12b.png)
![image](https://user-images.githubusercontent.com/44123869/188170990-86211869-47e5-4442-bf4d-94c920e31a6e.png)
