### PR TITLE
Set log level to 'fatal' in test environment

### DIFF
--- a/logger.ts
+++ b/logger.ts
@@ -3,6 +3,9 @@ import bunyanFormat from 'bunyan-format'
 
 const formatOut = bunyanFormat({ outputMode: 'short', color: true })
 
-const logger = bunyan.createLogger({ name: 'Approved Premises Ui', stream: formatOut, level: 'debug' })
+const logger =
+  process.env.NODE_ENV !== 'test'
+    ? bunyan.createLogger({ name: 'Approved Premises Ui', stream: formatOut, level: 'debug' })
+    : bunyan.createLogger({ name: 'Approved Premises Ui', stream: formatOut, level: 'fatal' })
 
 export default logger


### PR DESCRIPTION
Having detailed logs whilst running unit tests makes it harder to read test output and spot genuine problems.
The downside is this is it may be harder to spot issues when debugging tests. A work around to this could be creating a new environment for the jest tests to run in from `script/test` but I don't think silencing bunyan will cause any issues for now. 