### PR TITLE
Disable typechecking in jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
         "functions": 100
       }
     },
+    "globals": {
+      "ts-jest": {
+        "isolatedModules": true
+      }
+    },
     "testMatch": [
       "<rootDir>/(server|job)/**/?(*.)(cy|test).{ts,js,jsx,mjs}",
       "<rootDir>/wiremock/?(*.)(cy|test).{ts,js,jsx,mjs}"


### PR DESCRIPTION
This enables isolatedModules which has the effect of [disabling typechecking](https://kulshekhar.github.io/ts-jest/docs/getting-started/options/isolatedModules/).

Running this locally, this cuts down the test running time from 58 seconds to 13 seconds!

See https://github.com/ministryofjustice/hmpps-template-typescript/pull/116 for more context