### PR TITLE
(661) Previous applications dashboard

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -11,6 +11,7 @@ import departure from './integration_tests/mockApis/departure'
 import cancellation from './integration_tests/mockApis/cancellation'
 import lostBed from './integration_tests/mockApis/lostBed'
 import person from './integration_tests/mockApis/person'
+import applications from './integration_tests/mockApis/applications'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -38,6 +39,7 @@ export default defineConfig({
         ...cancellation,
         ...lostBed,
         ...person,
+        ...applications,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/integration_tests/e2e/apply/list.cy.ts
+++ b/integration_tests/e2e/apply/list.cy.ts
@@ -1,0 +1,32 @@
+import { StartPage, ListPage } from '../../pages/apply'
+
+import applicationSummaryFactory from '../../../server/testutils/factories/applicationSummary'
+import Page from '../../pages/page'
+
+context('Applications dashboard', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+  })
+
+  it('shows the dashboard ', () => {
+    // Given I am logged in
+    cy.signIn()
+
+    // And there are applications in the database
+    const applicationSummaries = applicationSummaryFactory.buildList(5)
+    cy.task('stubApplications', applicationSummaries)
+
+    // When I visit the Previous Applications page
+    const page = ListPage.visit()
+
+    // Then I should see all of the application summaries listed
+    page.shouldShowApplicationSummaries(applicationSummaries)
+
+    // And I the button should take me to the application start page
+    page.clickSubmit()
+
+    Page.verifyOnPage(StartPage)
+  })
+})

--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -1,0 +1,20 @@
+import { SuperAgentRequest } from 'superagent'
+
+import type { ApplicationSummary } from 'approved-premises'
+
+import { stubFor } from '../../wiremock'
+
+export default {
+  stubApplications: (applicationSummaries: ApplicationSummary): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/applications/previous`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: applicationSummaries,
+      },
+    }),
+}

--- a/integration_tests/pages/apply/index.ts
+++ b/integration_tests/pages/apply/index.ts
@@ -1,5 +1,6 @@
 import StartPage from './startPage'
 import EnterCRNPage from './enterCrn'
 import ConfirmDetailsPage from './confirmDetails'
+import ListPage from './list'
 
-export { ConfirmDetailsPage, EnterCRNPage, StartPage }
+export { ConfirmDetailsPage, EnterCRNPage, StartPage, ListPage }

--- a/integration_tests/pages/apply/list.ts
+++ b/integration_tests/pages/apply/list.ts
@@ -1,0 +1,35 @@
+import type { ApplicationSummary } from 'approved-premises'
+import Page from '../page'
+import paths from '../../../server/paths/apply'
+import { formatDateString } from '../../../server/utils/utils'
+
+export default class ListPage extends Page {
+  constructor() {
+    super('Previous applications dashboard')
+  }
+
+  static visit(): ListPage {
+    cy.visit(paths.applications.index.pattern)
+
+    return new ListPage()
+  }
+
+  shouldShowApplicationSummaries(applicationSummaries: Array<ApplicationSummary>): void {
+    applicationSummaries.forEach(summary => {
+      cy.contains(summary.person.name)
+        .should('have.attr', 'href', `/applications/${summary.id}`)
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('td').eq(0).contains(summary.person.crn)
+          cy.get('td').eq(1).contains(summary.tier.level)
+          cy.get('td').eq(2).contains(formatDateString(summary.arrivalDate))
+          cy.get('td').eq(3).contains(summary.status)
+        })
+    })
+  }
+
+  clickSubmit() {
+    cy.get('.govuk-button').click()
+  }
+}

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -12,6 +12,7 @@ declare module 'approved-premises' {
   export type Person = schemas['Person']
   export type PremisesCapacityItem = schemas['PremisesCapacityItem']
   export type PremisesCapacity = Array<PremisesCapacityItem>
+  export type ApplicationSummary = schemas['ApplicationSummary']
 
   export type NewBooking = Omit<Booking, 'id' | 'status' | 'arrival' | 'keyWorker'> & { keyWorkerId: string }
 
@@ -228,6 +229,19 @@ declare module 'approved-premises' {
     PremisesCapacityItem: {
       date: string
       availableBeds: number
+    }
+    RiskTier: {
+      level: string
+      lastUpdated: string
+    }
+    ApplicationSummary: {
+      id: string
+      person: Person
+      tier: schemas['RiskTier']
+      currentLocation: string
+      arrivalDate: string
+      daysSinceApplicationRecieved: number
+      status: 'In progress' | 'Submitted' | 'Information Requested' | 'Rejected'
     }
   }
 }

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -18,6 +18,21 @@ describe('applicationsController', () => {
     applicationsController = new ApplicationsController(applicationService)
   })
 
+  describe('list', () => {
+    it('renders the list view', async () => {
+      applicationService.tableRows.mockResolvedValue([])
+      const requestHandler = applicationsController.index()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/list', {
+        pageHeading: 'Approved Premises applications',
+        applicationSummaries: [],
+      })
+      expect(applicationService.tableRows).toHaveBeenCalled()
+    })
+  })
+
   describe('new', () => {
     it('renders the start page', () => {
       const requestHandler = applicationsController.new()

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -5,6 +5,14 @@ import paths from '../../paths/apply'
 export default class ApplicationsController {
   constructor(private readonly applicationService: ApplicationService) {}
 
+  index(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const applicationSummaries = await this.applicationService.tableRows(req.user.token)
+
+      res.render('applications/list', { pageHeading: 'Approved Premises applications', applicationSummaries })
+    }
+  }
+
   new(): RequestHandler {
     return (_req: Request, res: Response) => {
       res.render('applications/new', { pageHeading: 'Apply for an Approved Premises (AP) placement' })

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -1,0 +1,44 @@
+import nock from 'nock'
+
+import ApplicationClient from './applicationClient'
+import config from '../config'
+import applicationSummaryFactory from '../testutils/factories/applicationSummary'
+import paths from '../paths/api'
+
+describe('ApplicationClient', () => {
+  let fakeApprovedPremisesApi: nock.Scope
+  let applicationClient: ApplicationClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    config.apis.approvedPremises.url = 'http://localhost:8080'
+    fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
+    applicationClient = new ApplicationClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('all', () => {
+    it('should get all previous applications', async () => {
+      const previousApplications = applicationSummaryFactory.build()
+
+      fakeApprovedPremisesApi
+        .get(paths.applications.index.pattern)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, previousApplications)
+
+      const result = await applicationClient.all()
+
+      expect(result).toEqual(previousApplications)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+})

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,9 +1,10 @@
-/* istanbul ignore file */
-
 import crypto from 'crypto'
+
+import type { ApplicationSummary } from 'approved-premises'
 
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
+import paths from '../paths/api'
 
 export default class ApplicationClient {
   restClient: RestClient
@@ -12,7 +13,12 @@ export default class ApplicationClient {
     this.restClient = new RestClient('applicationClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
+  /* istanbul ignore next */
   async create(): Promise<string> {
     return crypto.randomUUID()
+  }
+
+  async all(): Promise<ApplicationSummary[]> {
+    return (await this.restClient.get({ path: paths.applications.index.pattern })) as ApplicationSummary[]
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -1,5 +1,13 @@
-import paths from './manage'
+import managePaths from './manage'
+import applyPaths from './apply'
 
 export default {
-  premises: { show: paths.premises.show, index: paths.premises.index, capacity: paths.premises.show.path('capacity') },
+  premises: {
+    show: managePaths.premises.show,
+    index: managePaths.premises.index,
+    capacity: managePaths.premises.show.path('capacity'),
+  },
+  applications: {
+    index: applyPaths.applications.index,
+  },
 }

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -1,6 +1,7 @@
 import { path } from 'static-path'
 
 const applicationsPath = path('/applications')
+const previousApplications = applicationsPath.path('previous')
 const applicationPath = applicationsPath.path(':id')
 
 const pagesPath = applicationPath.path('tasks/:task/pages/:page')
@@ -9,6 +10,7 @@ const paths = {
   applications: {
     new: applicationsPath.path('new'),
     create: applicationsPath,
+    index: previousApplications,
     pages: {
       show: pagesPath,
       update: pagesPath,

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -11,6 +11,7 @@ const paths = {
     new: applicationsPath.path('new'),
     create: applicationsPath,
     index: previousApplications,
+    show: applicationPath,
     pages: {
       show: pagesPath,
       update: pagesPath,

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -13,6 +13,7 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   get(paths.applications.new.pattern, applicationsController.new())
   post(paths.applications.create.pattern, applicationsController.create())
+  get(paths.applications.index.pattern, applicationsController.index())
 
   get(paths.applications.pages.show.pattern, pagesController.show())
   put(paths.applications.pages.update.pattern, pagesController.update())

--- a/server/testutils/factories/applicationSummary.ts
+++ b/server/testutils/factories/applicationSummary.ts
@@ -1,0 +1,24 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { ApplicationSummary } from 'approved-premises'
+import personFactory from './person'
+
+export default Factory.define<ApplicationSummary>(() => ({
+  id: faker.datatype.uuid(),
+  person: personFactory.build(),
+  arrivalDate: faker.date.future().toISOString(),
+  tier: {
+    level: faker.helpers.arrayElement(
+      ['A', 'B', 'C', 'D']
+        .map(letter => {
+          return [0, 1, 2, 3].map(number => `${letter}${number}`)
+        })
+        .flat(),
+    ),
+    lastUpdated: faker.date.recent().toISOString(),
+  },
+  currentLocation: faker.address.county(),
+  daysSinceApplicationRecieved: faker.datatype.number({ min: 0, max: 90 }),
+  status: faker.helpers.arrayElement(['In progress', 'Submitted', 'Information Requested', 'Rejected']),
+}))

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -4,6 +4,6 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import type { Person } from 'approved-premises'
 
 export default Factory.define<Person>(() => ({
-  crn: faker.datatype.uuid(),
+  crn: `C${faker.datatype.number({ min: 100000, max: 999999 })}`,
   name: faker.name.fullName(),
 }))

--- a/server/views/applications/_table.njk
+++ b/server/views/applications/_table.njk
@@ -1,0 +1,31 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% macro applicationsTable(title, rows) %}
+    {% if rows %}
+      {{
+        govukTable({
+          caption: title,
+          captionClasses: "govuk-table__caption--m",
+          firstCellIsHeader: true,
+          head: [
+            {
+              text: "Service user"
+            },
+            {
+              text: "CRN"
+            },
+            {
+              text: "Tier"
+            },
+            {
+              text: "Arrival date"
+            },
+              {
+              text: "Status"
+            }
+          ],
+          rows: rows
+        })
+      }}
+    {% endif %}
+{% endmacro %}

--- a/server/views/applications/list.njk
+++ b/server/views/applications/list.njk
@@ -1,0 +1,51 @@
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "moj/components/badge/macro.njk" import mojBadge %}
+{% from "./_table.njk" import applicationsTable %}
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+
+            <h1 class="govuk-heading-l">Previous applications dashboard</h1>
+
+            {{ govukTabs({
+                items: [
+                    {
+                        label: "Applications",
+                        id: "applications",
+                        panel: {
+                            html:applicationsTable("Applications", applicationSummaries)
+                        }
+                    },
+                    {
+                        label: "Further information requested",
+                        id: "further-information-requested",
+                        panel: {
+                            html: '<h3>TODO</h3>'
+                        }
+                    }
+                ]
+            }) }}
+
+        </div>
+
+        <div class="govuk-grid-column-two-thirds">
+            <h2 class="govuk-heading-m">Start a new application</h2>
+            <p>Start a new application for an Approved Premises by clicking on the start button below.</p>
+
+            {{ govukButton({
+                text: "Start now",
+                href: paths.applications.new()
+            }) }}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/wiremock/applicationStubs.ts
+++ b/wiremock/applicationStubs.ts
@@ -1,0 +1,15 @@
+import applicationSummaryFactory from '../server/testutils/factories/applicationSummary'
+
+export default [
+  {
+    request: {
+      method: 'GET',
+      url: `/applications/previous`,
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: applicationSummaryFactory.buildList(20),
+    },
+  },
+]

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -16,6 +16,7 @@ import departureStubs from './departuresStubs'
 import cancellationStubs from './cancellationStubs'
 import lostBedStubs from './lostBedStubs'
 import personStubs from './personStubs'
+import applicationStubs from './applicationStubs'
 
 import * as referenceDataStubs from './referenceDataStubs'
 import premisesCapacityItemFactory from '../server/testutils/factories/premisesCapacityItem'
@@ -119,6 +120,7 @@ stubs.push(
   ...boookingExtensionStubs,
   ...lostBedStubs,
   ...personStubs,
+  ...applicationStubs,
   ...Object.values(referenceDataStubs),
 )
 


### PR DESCRIPTION
# Context

We need to be able to show Probation Practicioner's previous applications so they know the status of each one.
[Trello card](https://trello.com/c/AVyXDHjh/661-previous-applications-dashboard).
This neccessitates a [new endpoint in the API which I have specced out here](https://github.com/ministryofjustice/approved-premises-api/pull/65)

# Changes in this PR
I have followed the patterns we have used throughout development in this repo. The client fetches the data, the service maps this into a form that is usable by the controller and the controller renders the page. 

## Screenshots of UI changes

### After
![image](https://user-images.githubusercontent.com/44123869/189678482-124fd406-8090-4c08-b40d-25211df9f415.png)
