### PR TITLE
(721) Use session data to populate question titles

### DIFF
--- a/integration_tests/e2e/apply/apply.cy.ts
+++ b/integration_tests/e2e/apply/apply.cy.ts
@@ -1,4 +1,4 @@
-import { StartPage, EnterCRNPage, ConfirmDetailsPage } from '../../pages/apply'
+import { StartPage, EnterCRNPage, ConfirmDetailsPage, SentenceTypePage, SituationPage } from '../../pages/apply'
 
 import personFactory from '../../../server/testutils/factories/person'
 
@@ -29,6 +29,25 @@ context('Apply', () => {
     // Then I should see the person's detail
     const confirmDetailsPage = new ConfirmDetailsPage(person)
     confirmDetailsPage.verifyPersonIsVisible()
+
+    // When I click submit
+    confirmDetailsPage.clickSubmit()
+
+    // Then I should be on the Sentence Type page
+    const sentenceTypePage = new SentenceTypePage()
+
+    // When I select 'Bail Placement'
+    sentenceTypePage.checkRadioByNameAndValue('sentenceType', 'bailPlacement')
+    sentenceTypePage.clickSubmit()
+
+    // Then I should be on the Situation Page
+    const situationPage = new SituationPage()
+
+    // When I select 'Bail Sentence'
+    situationPage.checkRadioByNameAndValue('situation', 'bailSentence')
+    situationPage.clickSubmit()
+
+    // Then I should be asked if I know the release date - TODO
   })
 
   it('shows an error message if the person is not found', () => {

--- a/integration_tests/pages/apply/enterCrn.ts
+++ b/integration_tests/pages/apply/enterCrn.ts
@@ -11,10 +11,6 @@ export default class EnterCRNPage extends Page {
     this.getTextInputByIdAndEnterDetails('crn', crn)
   }
 
-  public clickSubmit(): void {
-    cy.get('button').click()
-  }
-
   public shouldShowErrorMessage(person: Person): void {
     cy.get('.govuk-error-summary').should('contain', `No person with an CRN of '${person.crn}' was found`)
     cy.get(`[data-cy-error-crn]`).should('contain', `No person with an CRN of '${person.crn}' was found`)

--- a/integration_tests/pages/apply/index.ts
+++ b/integration_tests/pages/apply/index.ts
@@ -2,5 +2,7 @@ import StartPage from './startPage'
 import EnterCRNPage from './enterCrn'
 import ConfirmDetailsPage from './confirmDetails'
 import ListPage from './list'
+import SentenceTypePage from './sentenceType'
+import SituationPage from './situationPage'
 
-export { ConfirmDetailsPage, EnterCRNPage, StartPage, ListPage }
+export { ConfirmDetailsPage, EnterCRNPage, StartPage, ListPage, SentenceTypePage, SituationPage }

--- a/integration_tests/pages/apply/sentenceType.ts
+++ b/integration_tests/pages/apply/sentenceType.ts
@@ -1,0 +1,7 @@
+import Page from '../page'
+
+export default class SentenceTypePage extends Page {
+  constructor() {
+    super('Which of the following best describes the sentence type?')
+  }
+}

--- a/integration_tests/pages/apply/situationPage.ts
+++ b/integration_tests/pages/apply/situationPage.ts
@@ -1,0 +1,7 @@
+import Page from '../page'
+
+export default class SituationPage extends Page {
+  constructor() {
+    super('Which of the following options best describes the situation?')
+  }
+}

--- a/integration_tests/pages/manage/booking/find.ts
+++ b/integration_tests/pages/manage/booking/find.ts
@@ -16,10 +16,6 @@ export default class BookingFindPage extends Page {
     this.getTextInputByIdAndEnterDetails('crn', crn)
   }
 
-  clickSubmit(): void {
-    cy.get('button').click()
-  }
-
   completeForm(crn: string): void {
     this.enterCrn(crn)
     this.clickSubmit()

--- a/integration_tests/pages/manage/booking/new.ts
+++ b/integration_tests/pages/manage/booking/new.ts
@@ -44,10 +44,6 @@ export default class BookingNewPage extends Page {
     return cy.get('#expectedDepartureDate-year')
   }
 
-  clickSubmit(): void {
-    cy.get('button').click()
-  }
-
   completeForm(booking: Booking): void {
     this.getLegend('What is the expected arrival date?')
 

--- a/integration_tests/pages/manage/cancellationCreate.ts
+++ b/integration_tests/pages/manage/cancellationCreate.ts
@@ -13,10 +13,6 @@ export default class CancellationCreatePage extends Page {
     return new CancellationCreatePage()
   }
 
-  clickSubmit(): void {
-    cy.get('button').click()
-  }
-
   completeForm(cancellation: Cancellation): void {
     this.getLegend('Date of Cancellation')
     this.completeDateInputs('date', cancellation.date)

--- a/integration_tests/pages/manage/departureCreate.ts
+++ b/integration_tests/pages/manage/departureCreate.ts
@@ -40,8 +40,4 @@ export default class DepartureCreatePage extends Page {
     cy.get('textarea[name="departure[notes]"]').type(departure.notes)
     this.clickSubmit()
   }
-
-  clickSubmit() {
-    cy.get('button').click()
-  }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -69,4 +69,8 @@ export default abstract class Page {
     cy.get(`#${prefix}-month`).type(`${parsedDate.getMonth() + 1}`)
     cy.get(`#${prefix}-year`).type(parsedDate.getFullYear().toString())
   }
+
+  public clickSubmit(): void {
+    cy.get('button').click()
+  }
 }

--- a/server/controllers/apply/applications/pagesController.test.ts
+++ b/server/controllers/apply/applications/pagesController.test.ts
@@ -134,12 +134,14 @@ describe('pagesController', () => {
 
     it('updates an application and redirects to the next page', async () => {
       page.next.mockReturnValue('next-page')
-
+      const flashSpy = jest.fn()
       applicationService.save.mockReturnValue()
 
       const requestHandler = pagesController.update()
 
-      await requestHandler(request, response)
+      await requestHandler({ ...request, flash: flashSpy }, response)
+
+      expect(flashSpy).toHaveBeenCalledWith('previousPage', 'page-name')
 
       expect(applicationService.save).toHaveBeenCalledWith(page, request)
 

--- a/server/controllers/apply/applications/pagesController.ts
+++ b/server/controllers/apply/applications/pagesController.ts
@@ -45,7 +45,7 @@ export default class PagesController {
 
       try {
         this.applicationService.save(page, req)
-
+        req.flash('previousPage', page.name)
         res.redirect(paths.applications.pages.show({ id: req.params.id, task: req.params.task, page: page.next() }))
       } catch (err) {
         catchValidationErrorOrPropogate(

--- a/server/controllers/apply/applications/pagesController.ts
+++ b/server/controllers/apply/applications/pagesController.ts
@@ -12,7 +12,7 @@ import {
 import paths from '../../../paths/apply'
 import { UnknownPageError } from '../../../utils/errors'
 
-export default class ApplicationFormController {
+export default class PagesController {
   constructor(private readonly applicationService: ApplicationService, private readonly dataServices: DataServices) {}
 
   show(): RequestHandler {

--- a/server/data/restClientMetricsMiddleware.test.ts
+++ b/server/data/restClientMetricsMiddleware.test.ts
@@ -1,11 +1,6 @@
 import superagent from 'superagent'
 import nock from 'nock'
-import {
-  restClientMetricsMiddleware,
-  normalizePath,
-  requestHistogram,
-  timeoutCounter,
-} from './restClientMetricsMiddleware'
+import { restClientMetricsMiddleware, normalizePath, requestHistogram } from './restClientMetricsMiddleware'
 
 describe('restClientMetricsMiddleware', () => {
   afterEach(() => {
@@ -53,24 +48,6 @@ describe('restClientMetricsMiddleware', () => {
       expect(requestHistogramLabelsSpy).toHaveBeenCalledWith('httpbin.org', 'GET', '/', '200')
       expect(requestHistogramStartSpy).toHaveBeenCalledTimes(1)
       nock.cleanAll()
-    })
-  })
-
-  describe('timeout errors', () => {
-    // FIXME: For some reason this test just doesn't work, but the code really does count the timeouts...
-    it.skip('increment the timeoutCounter', async () => {
-      const timeoutCounterLabelsSpy = jest.spyOn(timeoutCounter, 'labels').mockReturnValue(timeoutCounter)
-      const timeoutCounterIncSpy = jest.spyOn(timeoutCounter, 'inc')
-
-      await superagent
-        .get('https://httpbin.org/delay/5') // implements a delay of 5 seconds
-        .use(restClientMetricsMiddleware)
-        .set('accept', 'json')
-        .timeout(100) // Wait 100ms for the server to start sending
-        .end()
-
-      expect(timeoutCounterLabelsSpy).toHaveBeenCalledWith('httpbin.org', 'GET', '/delay/5')
-      expect(timeoutCounterIncSpy).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/server/form-pages/apply/basic-information/placementDate.test.ts
+++ b/server/form-pages/apply/basic-information/placementDate.test.ts
@@ -1,17 +1,24 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+import { formatDateString } from '../../../utils/utils'
 
 import PlacementDate from './placementDate'
 
 describe('PlacementDate', () => {
-  describe('body', () => {
+  const releaseDate = new Date().toISOString()
+  const session = { 'basic-information': { 'release-date': { releaseDate } } }
+
+  describe('title and body', () => {
     it('should strip unknown attributes from the body', () => {
-      const page = new PlacementDate({
-        startDateSameAsReleaseDate: 'no',
-        'startDate-year': 2020,
-        'startDate-month': 12,
-        'startDate-day': 1,
-        something: 'else',
-      })
+      const page = new PlacementDate(
+        {
+          startDateSameAsReleaseDate: 'no',
+          'startDate-year': 2020,
+          'startDate-month': 12,
+          'startDate-day': 1,
+          something: 'else',
+        },
+        session,
+      )
 
       expect(page.body).toEqual({
         startDateSameAsReleaseDate: 'no',
@@ -19,35 +26,45 @@ describe('PlacementDate', () => {
         'startDate-month': 12,
         'startDate-day': 1,
       })
+      expect(page.title).toEqual(`Is ${formatDateString(releaseDate)} the date you want the placement to start?`)
     })
   })
 
-  itShouldHaveNextValue(new PlacementDate({}), '')
-  itShouldHavePreviousValue(new PlacementDate({}), 'oral-hearing')
+  itShouldHaveNextValue(new PlacementDate({}, session), '')
+  itShouldHavePreviousValue(new PlacementDate({}, session), 'oral-hearing')
 
   describe('errors', () => {
     it('should return an empty array if the release date is the same as the start date', () => {
-      const page = new PlacementDate({
-        startDateSameAsReleaseDate: 'yes',
-      })
+      const page = new PlacementDate(
+        {
+          startDateSameAsReleaseDate: 'yes',
+        },
+        session,
+      )
       expect(page.errors()).toEqual([])
     })
 
     describe('if the start date is not the same as the release date', () => {
       it('should return an empty array if the date is specified', () => {
-        const page = new PlacementDate({
-          startDateSameAsReleaseDate: 'no',
-          'startDate-year': 2020,
-          'startDate-month': 12,
-          'startDate-day': 1,
-        })
+        const page = new PlacementDate(
+          {
+            startDateSameAsReleaseDate: 'no',
+            'startDate-year': 2020,
+            'startDate-month': 12,
+            'startDate-day': 1,
+          },
+          session,
+        )
         expect(page.errors()).toEqual([])
       })
 
       it('should return an error if the date is not specified', () => {
-        const page = new PlacementDate({
-          startDateSameAsReleaseDate: 'no',
-        })
+        const page = new PlacementDate(
+          {
+            startDateSameAsReleaseDate: 'no',
+          },
+          session,
+        )
         expect(page.errors()).toEqual([
           {
             propertyName: 'startDate',
@@ -57,12 +74,15 @@ describe('PlacementDate', () => {
       })
 
       it('should return an error if the date is invalid', () => {
-        const page = new PlacementDate({
-          startDateSameAsReleaseDate: 'no',
-          'startDate-year': 999999,
-          'startDate-month': 99999,
-          'startDate-day': 9999,
-        })
+        const page = new PlacementDate(
+          {
+            startDateSameAsReleaseDate: 'no',
+            'startDate-year': 999999,
+            'startDate-month': 99999,
+            'startDate-day': 9999,
+          },
+          session,
+        )
         expect(page.errors()).toEqual([
           {
             propertyName: 'startDate',
@@ -73,7 +93,7 @@ describe('PlacementDate', () => {
     })
 
     it('should return an error if the startDateSameAsReleaseDate field is not populated', () => {
-      const page = new PlacementDate({})
+      const page = new PlacementDate({}, session)
       expect(page.errors()).toEqual([
         {
           propertyName: 'startDateSameAsReleaseDate',

--- a/server/form-pages/apply/basic-information/placementDate.ts
+++ b/server/form-pages/apply/basic-information/placementDate.ts
@@ -1,24 +1,32 @@
 import type { ObjectWithDateParts, YesOrNo } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { dateAndTimeInputsAreValidDates } from '../../../utils/utils'
+import {
+  dateAndTimeInputsAreValidDates,
+  formatDateString,
+  retrieveQuestionResponseFromSession,
+} from '../../../utils/utils'
 
 export default class PlacementDate implements TasklistPage {
   name = 'placement-date'
 
-  title = 'Is [release-date] the date you want the placement to start?'
+  title: string
 
   body: ObjectWithDateParts<'startDate'> & {
     startDateSameAsReleaseDate: YesOrNo
   }
 
-  constructor(body: Record<string, unknown>) {
+  constructor(body: Record<string, unknown>, session: Record<string, unknown>) {
     this.body = {
       'startDate-year': body['startDate-year'] as string,
       'startDate-month': body['startDate-month'] as string,
       'startDate-day': body['startDate-day'] as string,
       startDateSameAsReleaseDate: body.startDateSameAsReleaseDate as YesOrNo,
     }
+
+    const formattedReleaseDate = formatDateString(retrieveQuestionResponseFromSession(session, 'releaseDate'))
+
+    this.title = `Is ${formattedReleaseDate} the date you want the placement to start?`
   }
 
   next() {

--- a/server/form-pages/apply/basic-information/releaseDate.test.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.test.ts
@@ -5,13 +5,17 @@ import ReleaseDate from './releaseDate'
 describe('ReleaseDate', () => {
   describe('body', () => {
     it('should strip unknown attributes from the body', () => {
-      const page = new ReleaseDate({
-        knowReleaseDate: 'yes',
-        'releaseDate-year': 2022,
-        'releaseDate-month': 3,
-        'releaseDate-day': 3,
-        something: 'else',
-      })
+      const page = new ReleaseDate(
+        {
+          knowReleaseDate: 'yes',
+          'releaseDate-year': 2022,
+          'releaseDate-month': 3,
+          'releaseDate-day': 3,
+          something: 'else',
+        },
+        {},
+        'previousPage',
+      )
 
       expect(page.body).toEqual({
         knowReleaseDate: 'yes',
@@ -23,31 +27,41 @@ describe('ReleaseDate', () => {
   })
 
   describe('when knowReleaseDate is set to yes', () => {
-    itShouldHaveNextValue(new ReleaseDate({ knowReleaseDate: 'yes' }), 'placement-date')
+    itShouldHaveNextValue(new ReleaseDate({ knowReleaseDate: 'yes' }, {}, 'somePage'), 'placement-date')
   })
 
   describe('when knowReleaseDate is set to no', () => {
-    itShouldHaveNextValue(new ReleaseDate({ knowReleaseDate: 'no' }), 'oral-hearing')
+    itShouldHaveNextValue(new ReleaseDate({ knowReleaseDate: 'no' }, {}, 'somePage'), 'oral-hearing')
   })
 
-  itShouldHavePreviousValue(new ReleaseDate({}), 'release-type')
+  describe("previous returns the value passed into the previousPage parameter of the object's constructor", () => {
+    itShouldHavePreviousValue(new ReleaseDate({}, {}, 'previousPage'), 'previousPage')
+  })
 
   describe('errors', () => {
     describe('if the user knows the release date', () => {
       it('should return an empty array if the date is specified', () => {
-        const page = new ReleaseDate({
-          knowReleaseDate: 'yes',
-          'releaseDate-year': 2022,
-          'releaseDate-month': 3,
-          'releaseDate-day': 3,
-        })
+        const page = new ReleaseDate(
+          {
+            knowReleaseDate: 'yes',
+            'releaseDate-year': 2022,
+            'releaseDate-month': 3,
+            'releaseDate-day': 3,
+          },
+          {},
+          'somePage',
+        )
         expect(page.errors()).toEqual([])
       })
 
       it('should return an error if  the date is not populated', () => {
-        const page = new ReleaseDate({
-          knowReleaseDate: 'yes',
-        })
+        const page = new ReleaseDate(
+          {
+            knowReleaseDate: 'yes',
+          },
+          {},
+          'somePage',
+        )
         expect(page.errors()).toEqual([
           {
             propertyName: 'releaseDate',
@@ -57,12 +71,16 @@ describe('ReleaseDate', () => {
       })
 
       it('should return an error if the date is invalid', () => {
-        const page = new ReleaseDate({
-          knowReleaseDate: 'yes',
-          'releaseDate-year': 99,
-          'releaseDate-month': 99,
-          'releaseDate-day': 99,
-        })
+        const page = new ReleaseDate(
+          {
+            knowReleaseDate: 'yes',
+            'releaseDate-year': 99,
+            'releaseDate-month': 99,
+            'releaseDate-day': 99,
+          },
+          {},
+          'somePage',
+        )
         expect(page.errors()).toEqual([
           {
             propertyName: 'releaseDate',
@@ -73,14 +91,18 @@ describe('ReleaseDate', () => {
     })
 
     it('should return an empty array if the user does not know the release date', () => {
-      const page = new ReleaseDate({
-        knowReleaseDate: 'no',
-      })
+      const page = new ReleaseDate(
+        {
+          knowReleaseDate: 'no',
+        },
+        {},
+        'somePage',
+      )
       expect(page.errors()).toEqual([])
     })
 
     it('should return an error if the knowReleaseDate field is not populated', () => {
-      const page = new ReleaseDate({})
+      const page = new ReleaseDate({}, {}, 'somePage')
       expect(page.errors()).toEqual([
         {
           propertyName: 'knowReleaseDate',

--- a/server/form-pages/apply/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.ts
@@ -12,13 +12,17 @@ export default class ReleaseDate implements TasklistPage {
     knowReleaseDate: YesOrNo
   }
 
-  constructor(body: Record<string, unknown>) {
+  previousPage: string
+
+  constructor(body: Record<string, unknown>, _session: Record<string, unknown>, previousPage: string) {
     this.body = {
       'releaseDate-year': body['releaseDate-year'] as string,
       'releaseDate-month': body['releaseDate-month'] as string,
       'releaseDate-day': body['releaseDate-day'] as string,
       knowReleaseDate: body.knowReleaseDate as YesOrNo,
     }
+
+    this.previousPage = previousPage
   }
 
   next() {
@@ -26,7 +30,7 @@ export default class ReleaseDate implements TasklistPage {
   }
 
   previous() {
-    return 'release-type'
+    return this.previousPage
   }
 
   errors() {

--- a/server/form-pages/apply/basic-information/releaseType.test.ts
+++ b/server/form-pages/apply/basic-information/releaseType.test.ts
@@ -3,25 +3,27 @@ import { itShouldHavePreviousValue, itShouldHaveNextValue } from '../../shared-e
 import ReleaseType from './releaseType'
 
 describe('ReleaseType', () => {
+  const session = { 'basic-information': { 'sentence-type': { sentenceType: 'standardDeterminate' } } }
+
   describe('body', () => {
     it('should strip unknown attributes from the body', () => {
-      const page = new ReleaseType({ releaseType: 'rotl', something: 'else' })
+      const page = new ReleaseType({ releaseType: 'rotl', something: 'else' }, session)
 
       expect(page.body).toEqual({ releaseType: 'rotl' })
     })
   })
 
-  itShouldHavePreviousValue(new ReleaseType({}), 'sentence-type')
-  itShouldHaveNextValue(new ReleaseType({}), 'release-date')
+  itShouldHavePreviousValue(new ReleaseType({}, session), 'sentence-type')
+  itShouldHaveNextValue(new ReleaseType({}, session), 'release-date')
 
   describe('errors', () => {
     it('should return an empty array if the release type is populated', () => {
-      const page = new ReleaseType({ releaseType: 'rotl' })
+      const page = new ReleaseType({ releaseType: 'rotl' }, session)
       expect(page.errors()).toEqual([])
     })
 
     it('should return an errors if the release type is not populated', () => {
-      const page = new ReleaseType({ releaseType: '' })
+      const page = new ReleaseType({ releaseType: '' }, session)
       expect(page.errors()).toEqual([
         {
           propertyName: 'releaseType',
@@ -32,8 +34,60 @@ describe('ReleaseType', () => {
   })
 
   describe('items', () => {
+    describe('releaseType', () => {
+      it('if the release type is "standardDeterminate" then all the items should be shown', () => {
+        const items = new ReleaseType(
+          { releaseType: 'standardDeterminate' },
+          { 'basic-information': { 'sentence-type': { sentenceType: 'standardDeterminate' } } },
+        ).items()
+
+        expect(items.length).toEqual(5)
+        expect(items[0].value).toEqual('rotl')
+        expect(items[1].value).toEqual('hdc')
+        expect(items[2].value).toEqual('license')
+        expect(items[3].value).toEqual('pss')
+        expect(items[4].value).toEqual('rerelease')
+      })
+
+      it('if the release type is "extendedDeterminate" then the reduced list of items should be shown', () => {
+        const items = new ReleaseType(
+          { releaseType: 'extendedDeterminate' },
+          { 'basic-information': { 'sentence-type': { sentenceType: 'extendedDeterminate' } } },
+        ).items()
+
+        expect(items.length).toEqual(3)
+        expect(items[0].value).toEqual('rotl')
+        expect(items[1].value).toEqual('license')
+        expect(items[2].value).toEqual('rerelease')
+      })
+
+      it('if the release type is "ipp" then the reduced list of items should be shown', () => {
+        const items = new ReleaseType(
+          { releaseType: 'ipp' },
+          { 'basic-information': { 'sentence-type': { sentenceType: 'ipp' } } },
+        ).items()
+
+        expect(items.length).toEqual(3)
+        expect(items[0].value).toEqual('rotl')
+        expect(items[1].value).toEqual('license')
+        expect(items[2].value).toEqual('rerelease')
+      })
+
+      it('if the release type is "life" then the reduced list of items should be shown', () => {
+        const items = new ReleaseType(
+          { releaseType: 'life' },
+          { 'basic-information': { 'sentence-type': { sentenceType: 'life' } } },
+        ).items()
+
+        expect(items.length).toEqual(3)
+        expect(items[0].value).toEqual('rotl')
+        expect(items[1].value).toEqual('license')
+        expect(items[2].value).toEqual('rerelease')
+      })
+    })
+
     it('marks an option as selected when the releaseType is set', () => {
-      const page = new ReleaseType({ releaseType: 'rotl' })
+      const page = new ReleaseType({ releaseType: 'rotl' }, session)
 
       const selectedOptions = page.items().filter(item => item.checked)
 
@@ -42,7 +96,7 @@ describe('ReleaseType', () => {
     })
 
     it('marks no options as selected when the releaseType is not set', () => {
-      const page = new ReleaseType({})
+      const page = new ReleaseType({}, session)
 
       const selectedOptions = page.items().filter(item => item.checked)
 

--- a/server/form-pages/apply/basic-information/sentenceType.ts
+++ b/server/form-pages/apply/basic-information/sentenceType.ts
@@ -1,25 +1,27 @@
 import TasklistPage from '../../tasklistPage'
 
-export enum SentenceTypes {
-  standardDeterminate = 'Standard determinate custody',
-  communityOrder = 'Community Order',
-  bailPlacement = 'Bail placement',
-  extendedDeterminate = 'Extended determinate custody',
-  ipp = 'Indeterminate Public Protection',
-  nonStatutory = 'Non-statutory',
-  life = 'Life sentence',
-}
+export const sentenceTypes = {
+  standardDeterminate: 'Standard determinate custody',
+  communityOrder: 'Community Order',
+  bailPlacement: 'Bail placement',
+  extendedDeterminate: 'Extended determinate custody',
+  ipp: 'Indeterminate Public Protection',
+  nonStatutory: 'Non-statutory',
+  life: 'Life sentence',
+} as const
+
+export type SentenceTypesT = keyof typeof sentenceTypes
 
 export default class SentenceType implements TasklistPage {
   name = 'sentence-type'
 
   title = 'Which of the following best describes the sentence type?'
 
-  body: { sentenceType: keyof SentenceTypes }
+  body: { sentenceType: SentenceTypesT }
 
   constructor(body: Record<string, unknown>) {
     this.body = {
-      sentenceType: body.sentenceType as keyof SentenceTypes,
+      sentenceType: body.sentenceType as SentenceTypesT,
     }
   }
 
@@ -60,10 +62,10 @@ export default class SentenceType implements TasklistPage {
   }
 
   items() {
-    return Object.keys(SentenceTypes).map(key => {
+    return Object.keys(sentenceTypes).map(key => {
       return {
         value: key,
-        text: SentenceTypes[key],
+        text: sentenceTypes[key],
         checked: this.body.sentenceType === key,
       }
     })

--- a/server/form-pages/apply/basic-information/situation.test.ts
+++ b/server/form-pages/apply/basic-information/situation.test.ts
@@ -3,25 +3,30 @@ import { itShouldHavePreviousValue, itShouldHaveNextValue } from '../../shared-e
 import Situation from './situation'
 
 describe('Situation', () => {
+  let session = { 'basic-information': { 'sentence-type': { sentenceType: 'communityOrder' } } }
+  beforeEach(() => {
+    session = { 'basic-information': { 'sentence-type': { sentenceType: 'communityOrder' } } }
+  })
+
   describe('body', () => {
     it('should strip unknown attributes from the body', () => {
-      const page = new Situation({ situation: 'riskManagement', something: 'else' })
+      const page = new Situation({ situation: 'riskManagement', something: 'else' }, session)
 
       expect(page.body).toEqual({ situation: 'riskManagement' })
     })
   })
 
-  itShouldHavePreviousValue(new Situation({}), 'sentence-type')
-  itShouldHaveNextValue(new Situation({}), 'release-date')
+  itShouldHavePreviousValue(new Situation({}, session), 'sentence-type')
+  itShouldHaveNextValue(new Situation({}, session), 'release-date')
 
   describe('errors', () => {
     it('should return an empty array if the situation is populated', () => {
-      const page = new Situation({ situation: 'riskManagement' })
+      const page = new Situation({ situation: 'riskManagement' }, session)
       expect(page.errors()).toEqual([])
     })
 
     it('should return an errors if the situation is not populated', () => {
-      const page = new Situation({ situation: '' })
+      const page = new Situation({ situation: '' }, session)
       expect(page.errors()).toEqual([
         {
           propertyName: 'situation',
@@ -32,8 +37,36 @@ describe('Situation', () => {
   })
 
   describe('items', () => {
+    describe('sentenceType', () => {
+      it('if the sentence type is "communityOrder" then the items should be correct', () => {
+        const items = new Situation(
+          { situation: 'riskManagement' },
+          { 'basic-information': { 'sentence-type': { sentenceType: 'communityOrder' } } },
+        ).items()
+
+        expect(items.length).toEqual(2)
+        expect(items[0]).toEqual({ text: 'Referral for risk management', value: 'riskManagement', checked: true })
+        expect(items[1]).toEqual({ text: 'Residency management', value: 'residencyManagement', checked: false })
+      })
+
+      it('if the sentence type is "bailPlacement" then the items should be correct', () => {
+        const items = new Situation(
+          { situation: 'bailAssessment' },
+          { 'basic-information': { 'sentence-type': { sentenceType: 'bailPlacement' } } },
+        ).items()
+
+        expect(items.length).toEqual(2)
+        expect(items[0]).toEqual({
+          text: 'Bail assessment for community penalty',
+          value: 'bailAssessment',
+          checked: true,
+        })
+        expect(items[1]).toEqual({ text: 'Bail sentence', value: 'bailSentence', checked: false })
+      })
+    })
+
     it('marks an option as selected when the releaseType is set', () => {
-      const page = new Situation({ situation: 'riskManagement' })
+      const page = new Situation({ situation: 'riskManagement' }, session)
 
       const selectedOptions = page.items().filter(item => item.checked)
 
@@ -42,7 +75,7 @@ describe('Situation', () => {
     })
 
     it('marks no options as selected when the releaseType is not set', () => {
-      const page = new Situation({})
+      const page = new Situation({}, session)
 
       const selectedOptions = page.items().filter(item => item.checked)
 

--- a/server/form-pages/apply/basic-information/situation.ts
+++ b/server/form-pages/apply/basic-information/situation.ts
@@ -1,24 +1,35 @@
+import { SessionDataError } from '../../../utils/errors'
+import { retrieveQuestionResponseFromSession } from '../../../utils/utils'
 import TasklistPage from '../../tasklistPage'
+import { SentenceTypesT } from './sentenceType'
 
-// TODO: The options that appear will depend on the response to the previous question.
-// For now we'll return all options
-export enum Situations {
-  riskManagement = 'Referral for risk management',
-  residencyManagenent = 'Residency management',
-  bailAssessment = 'Bail assessment for community penalty',
-  bailSentence = 'Bail sentence',
-}
+const situations = {
+  riskManagement: 'Referral for risk management',
+  residencyManagement: 'Residency management',
+  bailAssessment: 'Bail assessment for community penalty',
+  bailSentence: 'Bail sentence',
+} as const
+
+type CommunityOrderSituations = Pick<typeof situations, 'riskManagement' | 'residencyManagement'>
+type BailPlacementSituations = Pick<typeof situations, 'bailAssessment' | 'bailSentence'>
+type SentenceType = Extract<SentenceTypesT, 'communityOrder' | 'bailPlacement'>
 
 export default class Situation implements TasklistPage {
   name = 'situation'
 
   title = 'Which of the following options best describes the situation?'
 
-  body: { situation: keyof Situations }
+  body: { situation: keyof (CommunityOrderSituations | BailPlacementSituations) }
 
-  constructor(body: Record<string, unknown>) {
+  situations: CommunityOrderSituations | BailPlacementSituations
+
+  constructor(body: Record<string, unknown>, session: Record<string, unknown>) {
+    const sessionSentenceType = retrieveQuestionResponseFromSession<SentenceType>(session, 'sentenceType')
+
+    this.situations = this.getSituationsForSentenceType(sessionSentenceType)
+
     this.body = {
-      situation: body.situation as keyof Situations,
+      situation: body.situation as keyof (CommunityOrderSituations | BailPlacementSituations),
     }
   }
 
@@ -44,12 +55,22 @@ export default class Situation implements TasklistPage {
   }
 
   items() {
-    return Object.keys(Situations).map(key => {
+    return Object.keys(this.situations).map(key => {
       return {
         value: key,
-        text: Situations[key],
+        text: this.situations[key],
         checked: this.body.situation === key,
       }
     })
+  }
+
+  getSituationsForSentenceType(sessionSentenceType: SentenceType): CommunityOrderSituations | BailPlacementSituations {
+    if (sessionSentenceType === 'communityOrder') {
+      return { riskManagement: situations.riskManagement, residencyManagement: situations.residencyManagement }
+    }
+    if (sessionSentenceType === 'bailPlacement') {
+      return { bailAssessment: situations.bailAssessment, bailSentence: situations.bailSentence }
+    }
+    throw new SessionDataError(`Unknown sentence type ${sessionSentenceType}`)
   }
 }

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -137,31 +137,31 @@ describe('ApplicationService', () => {
       request = createMock<Request>({ params: { id: 'some-uuid', task: 'my-task' } })
     })
 
-    it('should return the first page if the page is not defined', async () => {
+    it('should return the session and first page if the page is not defined', async () => {
       const result = await service.getCurrentPage(request, dataServices)
 
       expect(result).toBeInstanceOf(FirstPage)
 
-      expect(FirstPage).toHaveBeenCalledWith(request.body)
+      expect(FirstPage).toHaveBeenCalledWith(request.body, { 'my-task': {} })
     })
 
-    it('should return a page from a page list', async () => {
+    it('should return the session and a page from a page list', async () => {
       request.params.page = 'second'
 
       const result = await service.getCurrentPage(request, dataServices)
 
       expect(result).toBeInstanceOf(SecondPage)
 
-      expect(SecondPage).toHaveBeenCalledWith(request.body)
+      expect(SecondPage).toHaveBeenCalledWith(request.body, { 'my-task': {} })
     })
 
-    it('should initialize the page with the userInput if specified', async () => {
+    it('should initialize the page with the session and the userInput if specified', async () => {
       const userInput = { foo: 'bar' }
       const result = await service.getCurrentPage(request, dataServices, userInput)
 
       expect(result).toBeInstanceOf(FirstPage)
 
-      expect(FirstPage).toHaveBeenCalledWith(userInput)
+      expect(FirstPage).toHaveBeenCalledWith(userInput, { 'my-task': {} })
     })
 
     it('should load from the session if the body and userInput are blank', async () => {
@@ -172,7 +172,7 @@ describe('ApplicationService', () => {
 
       expect(result).toBeInstanceOf(FirstPage)
 
-      expect(FirstPage).toHaveBeenCalledWith({ foo: 'bar' })
+      expect(FirstPage).toHaveBeenCalledWith({ foo: 'bar' }, { 'my-task': { first: { foo: 'bar' } } })
     })
 
     it("should call a service's setup method if it exists", async () => {

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -45,9 +45,11 @@ export default class ApplicationService {
       throw new UnknownPageError()
     }
 
+    const previousPage = request.flash('previousPage').length ? request.flash('previousPage')[0] : ''
+
     const body = this.getBody(request, userInput)
     const session = this.getAllSessionData(request)
-    const page = new Page(body, session)
+    const page = new Page(body, session, previousPage)
 
     if (page.setup) {
       await page.setup(request, dataServices)

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -46,7 +46,8 @@ export default class ApplicationService {
     }
 
     const body = this.getBody(request, userInput)
-    const page = new Page(body)
+    const session = this.getAllSessionData(request)
+    const page = new Page(body, session)
 
     if (page.setup) {
       await page.setup(request, dataServices)
@@ -81,13 +82,17 @@ export default class ApplicationService {
     if (Object.keys(request.body).length) {
       return request.body
     }
-    return this.getSessionData(request)
+    return this.getSessionDataForPage(request)
   }
 
-  private getSessionData(request: Request) {
+  private getAllSessionData(request: Request) {
     const data = this.fetchOrInitializeSessionData(request.session, request.params.task, request.params.id)
 
-    return data.application[request.params.id][request.params.task][request.params.page] || {}
+    return data.application[request.params.id] || {}
+  }
+
+  private getSessionDataForPage(request: Request) {
+    return this.getAllSessionData(request)[request.params.task][request.params.page] || {}
   }
 
   async tableRows(token: string): Promise<(TextItem | HtmlItem)[][]> {

--- a/server/utils/errors.ts
+++ b/server/utils/errors.ts
@@ -10,6 +10,7 @@ export class ValidationError extends Error {
   }
 }
 
+export class SessionDataError extends Error {}
 export class UnknownPageError extends Error {}
 
 export class TasklistAPIError extends Error {

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,4 +1,5 @@
 import type { ObjectWithDateParts } from 'approved-premises'
+import { SessionDataError } from './errors'
 import {
   convertDateString,
   convertToTitleCase,
@@ -8,6 +9,7 @@ import {
   formatDate,
   formatDateString,
   dateAndTimeInputsAreValidDates,
+  retrieveQuestionResponseFromSession,
 } from './utils'
 
 describe('convert to title case', () => {
@@ -175,5 +177,21 @@ describe('dateAndTimeInputsAreValidDates', () => {
     const result = dateAndTimeInputsAreValidDates(obj, 'date')
 
     expect(result).toEqual(false)
+  })
+})
+
+describe('retrieveQuestionResponseFromSession', () => {
+  it("throws a SessionDataError if the property doesn't exist", () => {
+    expect(() => retrieveQuestionResponseFromSession({}, '')).toThrow(SessionDataError)
+  })
+
+  it('returns the property if it does existion', () => {
+    const questionResponse = retrieveQuestionResponseFromSession(
+      {
+        'basic-information': { 'question-response': { questionResponse: 'no' } },
+      },
+      'questionResponse',
+    )
+    expect(questionResponse).toBe('no')
   })
 })


### PR DESCRIPTION
# Context
Some parts of the questionaire are dependent on data stored in the session. 
This PR builds out that functionality in a couple of ways: 
1. The release date should be shown in the title of the placement date page
2. Dependent on the answer to the question 'Which of the following best describes the sentence type [name] is on?' the following question can either be 'What type of release will the application support' or 'Which of the following options best describes the situation' and the possible responses (in the form of radio buttons) for each question is also variable.

[Trello card](https://trello.com/c/QxdnPm4F/721-use-session-data-to-populate-form)

# Changes in this PR
- First we pass the session data to the constructor of every page object in the Apply questionaire
- Then we use the session passed into to populate the form pages
- Based on the session data we calculate the potential answers to the given questinos 
- Due to this change we also need to make the how the 'Back' button functionality works (see the last commit).  As we do not know in advance which page the user has come from we need to calculate the value of the 'Back' button dynamically

## Screenshots of UI changes

### After
![image](https://user-images.githubusercontent.com/44123869/190157926-7bf4c92f-dedf-4a9e-b8ba-95bb95636c44.png)
![image](https://user-images.githubusercontent.com/44123869/190158011-616e4db9-8b5e-4ac5-b8f1-0a7c385a7c60.png)
![image](https://user-images.githubusercontent.com/44123869/190158099-e2a3a43e-40a5-4a95-865a-91f11e391005.png)
![image](https://user-images.githubusercontent.com/44123869/190158222-de99aeb8-b7c6-4d84-8720-7cbe5539a28b.png)
