### PR TITLE
(627) Type of AP required screen

### DIFF
--- a/server/form-pages/apply/index.ts
+++ b/server/form-pages/apply/index.ts
@@ -1,7 +1,9 @@
 /* istanbul ignore file */
 
 import basicInfomationPages from './basic-information'
+import typeOfApPages from './type-of-ap'
 
 export default {
   'basic-information': basicInfomationPages,
+  'type-of-ap': typeOfApPages,
 }

--- a/server/form-pages/apply/type-of-ap/apType.test.ts
+++ b/server/form-pages/apply/type-of-ap/apType.test.ts
@@ -1,0 +1,54 @@
+import { itShouldHaveNextValue } from '../../shared-examples'
+import { convertKeyValuePairToRadioItems } from '../../../utils/formUtils'
+
+import ApType from './apType'
+
+jest.mock('../../../utils/formUtils')
+
+describe('ApType', () => {
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {
+      const page = new ApType({ type: 'standard', something: 'else' })
+
+      expect(page.body).toEqual({ type: 'standard' })
+    })
+  })
+
+  describe('when type is set to pipe', () => {
+    itShouldHaveNextValue(new ApType({ type: 'pipe' }), 'pipe-referral')
+  })
+
+  describe('when type is set to esap', () => {
+    itShouldHaveNextValue(new ApType({ type: 'esap' }), 'esap-placement-screening')
+  })
+
+  describe('when type is set to standard', () => {
+    itShouldHaveNextValue(new ApType({ type: 'standard' }), null)
+  })
+
+  describe('errors', () => {
+    it('should return an empty array if the type is populated', () => {
+      const page = new ApType({ type: 'riskManagement' })
+      expect(page.errors()).toEqual([])
+    })
+
+    it('should return an errors if the type is not populated', () => {
+      const page = new ApType({ type: '' })
+      expect(page.errors()).toEqual([
+        {
+          propertyName: 'type',
+          errorType: 'blank',
+        },
+      ])
+    })
+  })
+
+  describe('items', () => {
+    it('it calls convertKeyValuePairToRadioItems', () => {
+      const page = new ApType({ type: '' })
+      page.items()
+
+      expect(convertKeyValuePairToRadioItems).toHaveBeenCalled()
+    })
+  })
+})

--- a/server/form-pages/apply/type-of-ap/apType.ts
+++ b/server/form-pages/apply/type-of-ap/apType.ts
@@ -1,0 +1,52 @@
+import TasklistPage from '../../tasklistPage'
+import { convertKeyValuePairToRadioItems } from '../../../utils/formUtils'
+
+const apTypes = {
+  standard: 'Standard',
+  pipe: 'PIPE (physcologically informed planned environment)',
+  esap: 'ESAP (enhanced security AP)',
+} as const
+
+type ApTypes = typeof apTypes
+
+export default class ApType implements TasklistPage {
+  name = 'ap-type'
+
+  title = 'Which type of AP does xxxx require?'
+
+  body: { type: keyof ApTypes }
+
+  constructor(body: Record<string, unknown>) {
+    this.body = {
+      type: body.type as keyof ApTypes,
+    }
+  }
+
+  next() {
+    if (this.body.type === 'pipe') {
+      return 'pipe-referral'
+    }
+    if (this.body.type === 'esap') {
+      return 'esap-placement-screening'
+    }
+
+    return null
+  }
+
+  errors() {
+    const errors = []
+
+    if (!this.body.type) {
+      errors.push({
+        propertyName: 'type',
+        errorType: 'blank',
+      })
+    }
+
+    return errors
+  }
+
+  items() {
+    return convertKeyValuePairToRadioItems(apTypes, this.body.type)
+  }
+}

--- a/server/form-pages/apply/type-of-ap/index.ts
+++ b/server/form-pages/apply/type-of-ap/index.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+
+import ApType from './apType'
+
+const pages = {
+  'ap-type': ApType,
+}
+
+export default pages

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -40,5 +40,6 @@
     "blank": "You must specify the oral hearing date",
     "invalid": "The oral hearing date is an invalid date"
   },
-  "startDateSameAsReleaseDate": { "blank": "You must specify if the start date is the same as the release date" }
+  "startDateSameAsReleaseDate": { "blank": "You must specify if the start date is the same as the release date" },
+  "type": { "blank": "You must specify an AP type" }
 }

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -1,7 +1,7 @@
 import { createMock } from '@golevelup/ts-jest'
 
 import type { ErrorMessages } from 'approved-premises'
-import { dateFieldValues, convertObjectsToRadioItems } from './formUtils'
+import { dateFieldValues, convertObjectsToRadioItems, convertKeyValuePairToRadioItems } from './formUtils'
 
 describe('formUtils', () => {
   describe('dateFieldValues', () => {
@@ -113,6 +113,56 @@ describe('formUtils', () => {
           text: 'def',
           value: '345',
           checked: false,
+        },
+      ])
+    })
+  })
+
+  describe('convertKeyValuePairToRadioItems', () => {
+    const obj = {
+      foo: 'Foo',
+      bar: 'Bar',
+    }
+
+    it('should convert a key value pair to radio items', () => {
+      expect(convertKeyValuePairToRadioItems(obj, '')).toEqual([
+        {
+          value: 'foo',
+          text: 'Foo',
+          checked: false,
+        },
+        {
+          value: 'bar',
+          text: 'Bar',
+          checked: false,
+        },
+      ])
+    })
+
+    it('should check the checked item', () => {
+      expect(convertKeyValuePairToRadioItems(obj, 'foo')).toEqual([
+        {
+          value: 'foo',
+          text: 'Foo',
+          checked: true,
+        },
+        {
+          value: 'bar',
+          text: 'Bar',
+          checked: false,
+        },
+      ])
+
+      expect(convertKeyValuePairToRadioItems(obj, 'bar')).toEqual([
+        {
+          value: 'foo',
+          text: 'Foo',
+          checked: false,
+        },
+        {
+          value: 'bar',
+          text: 'Bar',
+          checked: true,
         },
       ])
     })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -36,3 +36,13 @@ export const convertObjectsToRadioItems = (
     }
   })
 }
+
+export function convertKeyValuePairToRadioItems<T>(object: T, checkedItem: string): Array<RadioItems> {
+  return Object.keys(object).map(key => {
+    return {
+      value: key,
+      text: object[key],
+      checked: checkedItem === key,
+    }
+  })
+}

--- a/server/views/applications/pages/type-of-ap/ap-type.njk
+++ b/server/views/applications/pages/type-of-ap/ap-type.njk
@@ -1,0 +1,21 @@
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  {{ govukRadios({
+    idPrefix: "type",
+    name: "type",
+    errorMessage: errors.type,
+    fieldset: {
+      legend: {
+        text: page.title,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
+    items: page.items()
+    }) }}
+
+{% endblock %}


### PR DESCRIPTION
This adds the Type of AP Required screen. We still need to fetch the offender's to populate the title, but this will come later:

## Screenshots

![image](https://user-images.githubusercontent.com/109774/190392778-6d2a5c2d-1a0b-4bbe-bbf8-aa227e3865ab.png)

![image](https://user-images.githubusercontent.com/109774/190392805-54586680-7747-4e8c-aa14-98d5f69a182d.png)
