### PR TITLE
(628) Add PIPE Related screens

### DIFF
--- a/server/form-pages/apply/basic-information/oralHearing.ts
+++ b/server/form-pages/apply/basic-information/oralHearing.ts
@@ -1,7 +1,7 @@
 import type { ObjectWithDateParts, YesOrNo } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { dateAndTimeInputsAreValidDates } from '../../../utils/utils'
+import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/utils'
 
 export default class OralHearing implements TasklistPage {
   name = 'oral-hearing'
@@ -40,7 +40,7 @@ export default class OralHearing implements TasklistPage {
     }
 
     if (this.body.knowOralHearingDate === 'yes') {
-      if (this.oralHearingDateIsBlank()) {
+      if (dateIsBlank(this.body)) {
         errors.push({
           propertyName: 'oralHearingDate',
           errorType: 'blank',
@@ -54,11 +54,5 @@ export default class OralHearing implements TasklistPage {
     }
 
     return errors
-  }
-
-  private oralHearingDateIsBlank(): boolean {
-    return (
-      !this.body['oralHearingDate-year'] && !this.body['oralHearingDate-month'] && !this.body['oralHearingDate-day']
-    )
   }
 }

--- a/server/form-pages/apply/basic-information/placementDate.ts
+++ b/server/form-pages/apply/basic-information/placementDate.ts
@@ -3,6 +3,7 @@ import type { ObjectWithDateParts, YesOrNo } from 'approved-premises'
 import TasklistPage from '../../tasklistPage'
 import {
   dateAndTimeInputsAreValidDates,
+  dateIsBlank,
   formatDateString,
   retrieveQuestionResponseFromSession,
 } from '../../../utils/utils'
@@ -48,7 +49,7 @@ export default class PlacementDate implements TasklistPage {
     }
 
     if (this.body.startDateSameAsReleaseDate === 'no') {
-      if (this.startDateIsBlank()) {
+      if (dateIsBlank(this.body)) {
         errors.push({
           propertyName: 'startDate',
           errorType: 'blank',
@@ -62,9 +63,5 @@ export default class PlacementDate implements TasklistPage {
     }
 
     return errors
-  }
-
-  private startDateIsBlank(): boolean {
-    return !this.body['startDate-year'] && !this.body['startDate-month'] && !this.body['startDate-day']
   }
 }

--- a/server/form-pages/apply/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.ts
@@ -1,7 +1,7 @@
 import type { ObjectWithDateParts, YesOrNo } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { dateAndTimeInputsAreValidDates } from '../../../utils/utils'
+import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/utils'
 
 export default class ReleaseDate implements TasklistPage {
   name = 'release-date'
@@ -44,7 +44,7 @@ export default class ReleaseDate implements TasklistPage {
     }
 
     if (this.body.knowReleaseDate === 'yes') {
-      if (this.releaseDateIsBlank()) {
+      if (dateIsBlank(this.body)) {
         errors.push({
           propertyName: 'releaseDate',
           errorType: 'blank',
@@ -58,9 +58,5 @@ export default class ReleaseDate implements TasklistPage {
     }
 
     return errors
-  }
-
-  private releaseDateIsBlank(): boolean {
-    return !this.body['releaseDate-year'] && !this.body['releaseDate-month'] && !this.body['releaseDate-day']
   }
 }

--- a/server/form-pages/apply/type-of-ap/index.ts
+++ b/server/form-pages/apply/type-of-ap/index.ts
@@ -1,9 +1,11 @@
 /* istanbul ignore file */
 
 import ApType from './apType'
+import PipeReferral from './pipeReferral'
 
 const pages = {
   'ap-type': ApType,
+  'pipe-referral': PipeReferral,
 }
 
 export default pages

--- a/server/form-pages/apply/type-of-ap/index.ts
+++ b/server/form-pages/apply/type-of-ap/index.ts
@@ -2,10 +2,12 @@
 
 import ApType from './apType'
 import PipeReferral from './pipeReferral'
+import PipeOpdScreening from './pipeOpdScreening'
 
 const pages = {
   'ap-type': ApType,
   'pipe-referral': PipeReferral,
+  'pipe-opd-screening': PipeOpdScreening,
 }
 
 export default pages

--- a/server/form-pages/apply/type-of-ap/pipeOpdScreening.test.ts
+++ b/server/form-pages/apply/type-of-ap/pipeOpdScreening.test.ts
@@ -1,0 +1,36 @@
+import { itShouldHavePreviousValue } from '../../shared-examples'
+
+import PipeOpdScreening from './pipeOpdScreening'
+
+describe('PipeOpdScreening', () => {
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {
+      const page = new PipeOpdScreening({
+        pipeReferral: 'yes',
+        pipeReferralMoreDetail: 'More detail',
+        something: 'else',
+      })
+
+      expect(page.body).toEqual({ pipeReferral: 'yes', pipeReferralMoreDetail: 'More detail' })
+    })
+  })
+
+  itShouldHavePreviousValue(new PipeOpdScreening({}), 'pipe-referral')
+
+  describe('errors', () => {
+    it('should return an empty array if the pipeReferral is populated', () => {
+      const page = new PipeOpdScreening({ pipeReferral: 'yes' })
+      expect(page.errors()).toEqual([])
+    })
+
+    it('should return an errors if the pipeReferral is not populated', () => {
+      const page = new PipeOpdScreening({ pipeReferral: '' })
+      expect(page.errors()).toEqual([
+        {
+          propertyName: 'pipeReferral',
+          errorType: 'blank',
+        },
+      ])
+    })
+  })
+})

--- a/server/form-pages/apply/type-of-ap/pipeOpdScreening.ts
+++ b/server/form-pages/apply/type-of-ap/pipeOpdScreening.ts
@@ -1,0 +1,35 @@
+import type { YesOrNo } from 'approved-premises'
+
+import TasklistPage from '../../tasklistPage'
+
+export default class PipeOpdReferral implements TasklistPage {
+  name = 'pipe-opd-screening'
+
+  title = 'Has a referral for PIPE placement been recommended in the OPD pathway plan?'
+
+  body: { pipeReferral: YesOrNo; pipeReferralMoreDetail: string }
+
+  constructor(body: Record<string, unknown>) {
+    this.body = {
+      pipeReferral: body.pipeReferral as YesOrNo,
+      pipeReferralMoreDetail: body.pipeReferralMoreDetail as string,
+    }
+  }
+
+  previous() {
+    return 'pipe-referral'
+  }
+
+  errors() {
+    const errors = []
+
+    if (!this.body.pipeReferral) {
+      errors.push({
+        propertyName: 'pipeReferral',
+        errorType: 'blank',
+      })
+    }
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/type-of-ap/pipeReferral.test.ts
+++ b/server/form-pages/apply/type-of-ap/pipeReferral.test.ts
@@ -1,0 +1,86 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+
+import PipeReferral from './pipeReferral'
+
+describe('PipeReferral', () => {
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {
+      const page = new PipeReferral({
+        opdPathway: 'yes',
+        'opdPathwayDate-year': 2022,
+        'opdPathwayDate-month': 3,
+        'opdPathwayDate-day': 3,
+        something: 'else',
+      })
+
+      expect(page.body).toEqual({
+        opdPathway: 'yes',
+        'opdPathwayDate-year': 2022,
+        'opdPathwayDate-month': 3,
+        'opdPathwayDate-day': 3,
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new PipeReferral({}), 'pipe-opd-screening')
+
+  itShouldHavePreviousValue(new PipeReferral({}), 'ap-type')
+
+  describe('errors', () => {
+    describe('if opdPathway is yes', () => {
+      it('should return an empty array if the date is specified', () => {
+        const page = new PipeReferral({
+          opdPathway: 'yes',
+          'opdPathwayDate-year': 2022,
+          'opdPathwayDate-month': 3,
+          'opdPathwayDate-day': 3,
+        })
+        expect(page.errors()).toEqual([])
+      })
+
+      it('should return an error if  the date is not populated', () => {
+        const page = new PipeReferral({
+          opdPathway: 'yes',
+        })
+        expect(page.errors()).toEqual([
+          {
+            propertyName: 'opdPathwayDate',
+            errorType: 'blank',
+          },
+        ])
+      })
+
+      it('should return an error if the date is invalid', () => {
+        const page = new PipeReferral({
+          opdPathway: 'yes',
+          'opdPathwayDate-year': 99,
+          'opdPathwayDate-month': 99,
+          'opdPathwayDate-day': 99,
+        })
+        expect(page.errors()).toEqual([
+          {
+            propertyName: 'opdPathwayDate',
+            errorType: 'invalid',
+          },
+        ])
+      })
+    })
+
+    it('should return an empty array if opdPathway in no', () => {
+      const page = new PipeReferral({
+        opdPathway: 'no',
+      })
+      expect(page.errors()).toEqual([])
+    })
+
+    it('should return an error if the opdPathway field is not populated', () => {
+      const page = new PipeReferral({})
+      expect(page.errors()).toEqual([
+        {
+          propertyName: 'opdPathway',
+          errorType: 'blank',
+        },
+      ])
+    })
+  })
+})

--- a/server/form-pages/apply/type-of-ap/pipeReferral.ts
+++ b/server/form-pages/apply/type-of-ap/pipeReferral.ts
@@ -1,0 +1,56 @@
+import type { YesOrNo, ObjectWithDateParts } from 'approved-premises'
+
+import TasklistPage from '../../tasklistPage'
+import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/utils'
+
+export default class PipeReferral implements TasklistPage {
+  name = 'pipe-referral'
+
+  body: ObjectWithDateParts<'opdPathwayDate'> & { opdPathway: YesOrNo }
+
+  title = 'Has xxxx been screened into the OPD pathway?'
+
+  constructor(body: Record<string, unknown>) {
+    this.body = {
+      'opdPathwayDate-year': body['opdPathwayDate-year'] as string,
+      'opdPathwayDate-month': body['opdPathwayDate-month'] as string,
+      'opdPathwayDate-day': body['opdPathwayDate-day'] as string,
+      opdPathway: body.opdPathway as YesOrNo,
+    }
+  }
+
+  next() {
+    return 'pipe-opd-screening'
+  }
+
+  previous() {
+    return 'ap-type'
+  }
+
+  errors() {
+    const errors = []
+
+    if (!this.body.opdPathway) {
+      errors.push({
+        propertyName: 'opdPathway',
+        errorType: 'blank',
+      })
+    }
+
+    if (this.body.opdPathway === 'yes') {
+      if (dateIsBlank(this.body)) {
+        errors.push({
+          propertyName: 'opdPathwayDate',
+          errorType: 'blank',
+        })
+      } else if (!dateAndTimeInputsAreValidDates(this.body, 'opdPathwayDate')) {
+        errors.push({
+          propertyName: 'opdPathwayDate',
+          errorType: 'invalid',
+        })
+      }
+    }
+
+    return errors
+  }
+}

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -46,5 +46,8 @@
   "opdPathwayDate": {
     "blank": "You must enter an OPD Pathway date",
     "invalid": "The OPD Pathway date is an invalid date"
+  },
+  "pipeReferral": {
+    "blank": "You must specify if  a referral for PIPE placement has been recommended in the OPD pathway plan"
   }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -41,5 +41,10 @@
     "invalid": "The oral hearing date is an invalid date"
   },
   "startDateSameAsReleaseDate": { "blank": "You must specify if the start date is the same as the release date" },
-  "type": { "blank": "You must specify an AP type" }
+  "type": { "blank": "You must specify an AP type" },
+  "opdPathway": { "blank": "You must specify if xxxx has been screened into the OPD pathway" },
+  "opdPathwayDate": {
+    "blank": "You must enter an OPD Pathway date",
+    "invalid": "The OPD Pathway date is an invalid date"
+  }
 }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -10,6 +10,7 @@ import {
   formatDateString,
   dateAndTimeInputsAreValidDates,
   retrieveQuestionResponseFromSession,
+  dateIsBlank,
 } from './utils'
 
 describe('convert to title case', () => {
@@ -193,5 +194,27 @@ describe('retrieveQuestionResponseFromSession', () => {
       'questionResponse',
     )
     expect(questionResponse).toBe('no')
+  })
+})
+
+describe('dateIsBlank', () => {
+  it('returns false if the date is not blank', () => {
+    const date: ObjectWithDateParts<'field'> = {
+      'field-day': '12',
+      'field-month': '1',
+      'field-year': '2022',
+    }
+
+    expect(dateIsBlank(date)).toEqual(false)
+  })
+
+  it('returns true if the date is blank', () => {
+    const date: ObjectWithDateParts<'field'> = {
+      'field-day': '',
+      'field-month': '',
+      'field-year': '',
+    }
+
+    expect(dateIsBlank(date)).toEqual(true)
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -105,6 +105,7 @@ export const dateAndTimeInputsAreValidDates = <K extends string | number>(
 
   return true
 }
+
 /**
  * Retrieves response for a given question from the session object.
  * @param sessionData the session data for an application.
@@ -117,4 +118,9 @@ export const retrieveQuestionResponseFromSession = <T>(sessionData: Record<strin
   } catch (e) {
     throw new SessionDataError(`Question ${question} was not found in the session`)
   }
+}
+
+export const dateIsBlank = <T = ObjectWithDateParts<string | number>>(body: T): boolean => {
+  const fields = Object.keys(body).filter(key => key.match(/-[year|month|day]/))
+  return fields.every(field => !body[field])
 }

--- a/server/views/applications/pages/type-of-ap/pipe-opd-screening.njk
+++ b/server/views/applications/pages/type-of-ap/pipe-opd-screening.njk
@@ -1,0 +1,42 @@
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  {{ govukRadios({
+      idPrefix: "pipeReferral",
+      name: "pipeReferral",
+      errorMessage: errors.pipeReferral,
+      fieldset: {
+        legend: {
+          text: page.title,
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--l"
+        }
+      },
+      items: [
+        {
+          value: "yes",
+          text: "Yes",
+          checked: pipeReferral == 'yes'
+        },
+        {
+          value: "no",
+          text: "No",
+          checked: pipeReferral == 'no'
+        }
+      ]
+    }) }}
+
+  {{ govukTextarea({
+      name: "pipeReferralMoreDetail",
+      id: "pipeReferralMoreDetail",
+      value: pipeReferralMoreDetail,
+      label: {
+        text: "Provide any additional detail about why xxxx needs a PIPE placement."
+      }
+    }) }}
+
+{% endblock %}

--- a/server/views/applications/pages/type-of-ap/pipe-referral.njk
+++ b/server/views/applications/pages/type-of-ap/pipe-referral.njk
@@ -1,0 +1,54 @@
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  {% set opdPathwayDateHTML %}
+  {{ govukDateInput({
+      id: "opdPathwayDate",
+      namePrefix: "opdPathwayDate",
+      errorMessage: errors.opdPathwayDate,
+      fieldset: {
+        legend: {
+          text: "When was xxxx's last consultation or formulation?"
+        }
+      },
+      hint: {
+        text: "For example, 27 3 2007"
+      },
+      items: dateFieldValues('opdPathwayDate', errors)
+    }) }}
+  {% endset -%}
+
+  {{ govukRadios({
+    idPrefix: "opdPathway",
+    name: "opdPathway",
+    errorMessage: errors.opdPathway,
+    fieldset: {
+      legend: {
+        text: page.title,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
+    items: [
+      {
+        value: "yes",
+        text: "Yes",
+        checked: opdPathway == 'yes',
+        conditional: {
+          html: opdPathwayDateHTML
+        }
+      },
+      {
+        text: "No",
+        value: "no",
+        checked: opdPathway == 'no'
+      }
+    ]
+    }) }}
+
+{% endblock %}


### PR DESCRIPTION
This adds the two PIPE related screens to the type of AP journey

## Screenshots

![image](https://user-images.githubusercontent.com/109774/190447353-1c89c64f-d23b-44d1-86fa-905380519f2b.png)
![image](https://user-images.githubusercontent.com/109774/190447383-8917ee2c-e209-42c0-ba54-ce226f2ecf10.png)
![image](https://user-images.githubusercontent.com/109774/190447425-d5a76c5a-b727-4d29-ab2c-fe025e4de99d.png)

![image](https://user-images.githubusercontent.com/109774/190447478-da414c24-2e7f-4e9d-bb9c-8153e643df5b.png)
![image](https://user-images.githubusercontent.com/109774/190447514-2ec3d44d-2e41-401c-9e77-4a0f9eaed3ab.png)
