### PR TITLE
(721) -  fix - Use session to store previous page value

### DIFF
--- a/integration_tests/e2e/apply/apply.cy.ts
+++ b/integration_tests/e2e/apply/apply.cy.ts
@@ -1,6 +1,8 @@
 import { StartPage, EnterCRNPage, ConfirmDetailsPage, SentenceTypePage, SituationPage } from '../../pages/apply'
 
 import personFactory from '../../../server/testutils/factories/person'
+import Page from '../../pages/page'
+import ReleaseDatePage from '../../pages/apply/releaseDate'
 
 context('Apply', () => {
   beforeEach(() => {
@@ -47,7 +49,8 @@ context('Apply', () => {
     situationPage.checkRadioByNameAndValue('situation', 'bailSentence')
     situationPage.clickSubmit()
 
-    // Then I should be asked if I know the release date - TODO
+    // Then I should be asked if I know the release date
+    Page.verifyOnPage(ReleaseDatePage)
   })
 
   it('shows an error message if the person is not found', () => {

--- a/integration_tests/pages/apply/releaseDate.ts
+++ b/integration_tests/pages/apply/releaseDate.ts
@@ -1,0 +1,7 @@
+import Page from '../page'
+
+export default class ReleaseDatePage extends Page {
+  constructor() {
+    super('Do you know Robert Brown’s release date?')
+  }
+}

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -8,6 +8,7 @@ declare module 'express-session' {
     returnTo: string
     nowInMinutes: number
     application: Record<string, unknown>
+    previousPage: string
   }
 }
 

--- a/server/controllers/apply/applications/pagesController.test.ts
+++ b/server/controllers/apply/applications/pagesController.test.ts
@@ -134,14 +134,12 @@ describe('pagesController', () => {
 
     it('updates an application and redirects to the next page', async () => {
       page.next.mockReturnValue('next-page')
-      const flashSpy = jest.fn()
+
       applicationService.save.mockReturnValue()
 
       const requestHandler = pagesController.update()
 
-      await requestHandler({ ...request, flash: flashSpy }, response)
-
-      expect(flashSpy).toHaveBeenCalledWith('previousPage', 'page-name')
+      await requestHandler({ ...request }, response)
 
       expect(applicationService.save).toHaveBeenCalledWith(page, request)
 

--- a/server/controllers/apply/applications/pagesController.ts
+++ b/server/controllers/apply/applications/pagesController.ts
@@ -45,7 +45,6 @@ export default class PagesController {
 
       try {
         this.applicationService.save(page, req)
-        req.flash('previousPage', page.name)
         res.redirect(paths.applications.pages.show({ id: req.params.id, task: req.params.task, page: page.next() }))
       } catch (err) {
         catchValidationErrorOrPropogate(

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -132,12 +132,11 @@ describe('ApplicationService', () => {
   describe('getCurrentPage', () => {
     let request: DeepMocked<Request>
     const dataServices = createMock<DataServices>({}) as DataServices
-    const flashSpy = jest.fn()
 
     beforeEach(() => {
       request = createMock<Request>({
         params: { id: 'some-uuid', task: 'my-task' },
-        flash: flashSpy.mockImplementation((_previousPage: string) => []),
+        session: { previousPage: '' },
       })
     })
 
@@ -190,11 +189,9 @@ describe('ApplicationService', () => {
       expect(setup).toHaveBeenCalledWith(request, dataServices)
     })
 
-    it("should call the flash with 'previousPage' and call the Page objects constructor with that value", async () => {
-      flashSpy.mockImplementation((_previousPage: string) => ['previous-page-name'])
+    it("retrieve the 'previousPage' value from the session and call the Page object's constructor with that value", async () => {
+      request.session.previousPage = 'previous-page-name'
       await service.getCurrentPage(request, dataServices)
-
-      expect(flashSpy).toHaveBeenCalledWith('previousPage')
 
       expect(FirstPage).toHaveBeenCalledWith(request.body, { 'my-task': {} }, 'previous-page-name')
     })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -45,11 +45,9 @@ export default class ApplicationService {
       throw new UnknownPageError()
     }
 
-    const previousPage = request.flash('previousPage').length ? request.flash('previousPage')[0] : ''
-
     const body = this.getBody(request, userInput)
     const session = this.getAllSessionData(request)
-    const page = new Page(body, session, previousPage)
+    const page = new Page(body, session, request.session.previousPage)
 
     if (page.setup) {
       await page.setup(request, dataServices)
@@ -66,6 +64,7 @@ export default class ApplicationService {
       request.session = this.fetchOrInitializeSessionData(request.session, request.params.task, request.params.id)
 
       request.session.application[request.params.id][request.params.task][request.params.page] = page.body
+      request.session.previousPage = page.name
     }
   }
 


### PR DESCRIPTION
#169 broke the apply journey when reaching the 'release date' question as we weren't passing a value to the 'Back' button.
The value we were passing as 'previousPage' was not being persisted in the flash.
Instead I am suggesting we store the 'previousPage' in the session instead of the flash as this will be more robust.

The tests didn't fail on this issue as we weren't verifying that we had reached the 'release date' page so I corrected this error before implementing the solution.
