### PR TITLE
Specify version of node to use for Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,15 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3.4.1
+        with:
+          node-version-file: '.node-version'
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
We were previously seeing the below error in the console when running the tests in CI, this should fix that.
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'approved-premises-ui@0.0.1',
npm WARN EBADENGINE   required: { node: '^18', npm: '^8' },
npm WARN EBADENGINE   current: { node: 'v16.17.0', npm: '8.15.0' }
npm WARN EBADENGINE }
```
