### PR TITLE
(745) Fetch keyworkers from reference data endpoint

### DIFF
--- a/integration_tests/e2e/manage/booking.cy.ts
+++ b/integration_tests/e2e/manage/booking.cy.ts
@@ -9,11 +9,14 @@ import Page from '../../pages/page'
 import BookingConfirmation from '../../pages/manage/booking/confirmation'
 import personFactory from '../../../server/testutils/factories/person'
 
+const keyWorkers = keyWorkerFactory.buildList(5)
+
 context('Booking', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubKeyWorkers', { keyWorkers })
   })
 
   it('should show the CRN form followed by the booking form', () => {
@@ -23,7 +26,7 @@ context('Booking', () => {
       name: person.name,
       expectedArrivalDate: new Date(Date.UTC(2022, 5, 1, 0, 0, 0)).toISOString(),
       expectedDepartureDate: new Date(Date.UTC(2022, 5, 3, 0, 0, 0)).toISOString(),
-      keyWorker: keyWorkerFactory.build({ name: 'Alex Evans' }),
+      keyWorker: keyWorkers[1],
     })
     const firstOvercapacityPeriodStartDate = premisesCapacityItemFactory.build({
       date: new Date(2023, 0, 1).toISOString(),
@@ -103,7 +106,7 @@ context('Booking', () => {
 
       expect(requestBody.expectedArrivalDate).equal(booking.expectedArrivalDate)
       expect(requestBody.expectedDepartureDate).equal(booking.expectedDepartureDate)
-      expect(requestBody.keyWorkerId).equal('55126a32-0d27-4044-bc4e-e21c01632e56')
+      expect(requestBody.keyWorkerId).equal(booking.keyWorker.id)
     })
   })
 

--- a/integration_tests/mockApis/booking.ts
+++ b/integration_tests/mockApis/booking.ts
@@ -1,9 +1,25 @@
-import type { Booking } from 'approved-premises'
+import type { Booking, KeyWorker } from 'approved-premises'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import { errorStub } from '../../wiremock/utils'
 
 export default {
+  stubKeyWorkers: (args: { keyWorkers: Array<KeyWorker> }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: '/reference-data/key-workers',
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: args.keyWorkers.map(keyWorker => {
+          return { ...keyWorker, isActive: true }
+        }),
+      },
+    }),
   stubBookingCreate: (args: { premisesId: string; booking: Booking }) =>
     stubFor({
       request: {

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -97,6 +97,12 @@ declare module 'approved-premises' {
     checked?: boolean
   }
 
+  export interface SelectOptions {
+    text: string
+    value: string
+    selected?: boolean
+  }
+
   export interface IdentityBarMenuItem {
     classes: string
     href: string

--- a/server/controllers/manage/bookingsController.ts
+++ b/server/controllers/manage/bookingsController.ts
@@ -29,12 +29,15 @@ export default class BookingsController {
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
       const crnArr = req.flash('crn')
+
       if (crnArr.length) {
+        const keyWorkers = await this.bookingService.getKeyWorkers(req.user.token)
         const person = await this.personService.findByCrn(req.user.token, crnArr[0])
 
         return res.render(`bookings/new`, {
           pageHeading: 'Make a booking',
           premisesId,
+          keyWorkers,
           ...person,
           errors,
           errorSummary,

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -1,23 +1,31 @@
 import BookingService from './bookingService'
 import BookingClient from '../data/bookingClient'
+import ReferenceDataClient from '../data/referenceDataClient'
 
 import newBookingFactory from '../testutils/factories/newBooking'
 import bookingFactory from '../testutils/factories/booking'
+import referenceDataFactory from '../testutils/factories/referenceData'
+
 import { formatDate } from '../utils/utils'
 import paths from '../paths/manage'
 
 jest.mock('../data/bookingClient.ts')
+jest.mock('../data/referenceDataClient.ts')
 
 describe('BookingService', () => {
   const bookingClient = new BookingClient(null) as jest.Mocked<BookingClient>
+  const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
 
   const bookingClientFactory = jest.fn()
-  const service = new BookingService(bookingClientFactory)
+  const referenceDataClientFactory = jest.fn()
+
+  const service = new BookingService(bookingClientFactory, referenceDataClientFactory)
   const token = 'SOME_TOKEN'
 
   beforeEach(() => {
     jest.resetAllMocks()
     bookingClientFactory.mockReturnValue(bookingClient)
+    referenceDataClientFactory.mockReturnValue(referenceDataClient)
   })
 
   describe('create', () => {
@@ -69,6 +77,20 @@ describe('BookingService', () => {
 
       expect(bookingClientFactory).toHaveBeenCalledWith(token)
       expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
+    })
+  })
+
+  describe('getKeyWorkers', () => {
+    it('should return the keyworker data needed', async () => {
+      const keyWorkers = referenceDataFactory.buildList(2)
+
+      referenceDataClient.getReferenceData.mockResolvedValue(keyWorkers)
+
+      const result = await service.getKeyWorkers(token)
+
+      expect(result).toEqual(keyWorkers)
+      expect(referenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('key-workers')
     })
   })
 

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -1,8 +1,15 @@
 import { isSameDay, isWithinInterval, addDays } from 'date-fns'
 
-import type { Booking, NewBooking, TableRow, GroupedListofBookings, BookingExtension } from 'approved-premises'
+import type {
+  Booking,
+  NewBooking,
+  TableRow,
+  GroupedListofBookings,
+  BookingExtension,
+  ReferenceData,
+} from 'approved-premises'
 
-import type { RestClientBuilder } from '../data'
+import type { RestClientBuilder, ReferenceDataClient } from '../data'
 import BookingClient from '../data/bookingClient'
 import { convertDateString, formatDate } from '../utils/utils'
 import paths from '../paths/manage'
@@ -10,7 +17,10 @@ import paths from '../paths/manage'
 export default class BookingService {
   UPCOMING_WINDOW_IN_DAYS = 5
 
-  constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
+  constructor(
+    private readonly bookingClientFactory: RestClientBuilder<BookingClient>,
+    private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
+  ) {}
 
   async create(token: string, premisesId: string, booking: NewBooking): Promise<Booking> {
     const bookingClient = this.bookingClientFactory(token)
@@ -26,6 +36,14 @@ export default class BookingService {
     const booking = await bookingClient.find(premisesId, bookingId)
 
     return booking
+  }
+
+  async getKeyWorkers(token: string): Promise<Array<ReferenceData>> {
+    const referenceDataClient = this.referenceDataClientFactory(token)
+
+    const keyWorkers = await referenceDataClient.getReferenceData('key-workers')
+
+    return keyWorkers
   }
 
   async listOfBookingsForPremisesId(token: string, premisesId: string): Promise<Array<TableRow>> {

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -27,7 +27,7 @@ export const services = () => {
   const userService = new UserService(hmppsAuthClient)
   const premisesService = new PremisesService(approvedPremisesClientBuilder)
   const personService = new PersonService(personClient)
-  const bookingService = new BookingService(bookingClientBuilder)
+  const bookingService = new BookingService(bookingClientBuilder, referenceDataClientBuilder)
   const arrivalService = new ArrivalService(bookingClientBuilder)
   const nonArrivalService = new NonArrivalService(bookingClientBuilder)
   const departureService = new DepartureService(bookingClientBuilder, referenceDataClientBuilder)

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -1,7 +1,12 @@
 import { createMock } from '@golevelup/ts-jest'
 
 import type { ErrorMessages } from 'approved-premises'
-import { dateFieldValues, convertObjectsToRadioItems, convertKeyValuePairToRadioItems } from './formUtils'
+import {
+  dateFieldValues,
+  convertObjectsToRadioItems,
+  convertKeyValuePairToRadioItems,
+  convertObjectsToSelectOptions,
+} from './formUtils'
 
 describe('formUtils', () => {
   describe('dateFieldValues', () => {
@@ -163,6 +168,63 @@ describe('formUtils', () => {
           value: 'bar',
           text: 'Bar',
           checked: true,
+        },
+      ])
+    })
+  })
+
+  describe('convertObjectsToSelectOptions', () => {
+    const objects = [
+      {
+        id: '123',
+        name: 'abc',
+      },
+      {
+        id: '345',
+        name: 'def',
+      },
+    ]
+
+    it('converts objects to an array of select options', () => {
+      const result = convertObjectsToSelectOptions(objects, 'name', 'id', 'field', {})
+
+      expect(result).toEqual([
+        {
+          value: '',
+          text: 'Select a keyworker',
+          selected: true,
+        },
+        {
+          text: 'abc',
+          value: '123',
+          selected: false,
+        },
+        {
+          text: 'def',
+          value: '345',
+          selected: false,
+        },
+      ])
+    })
+
+    it('marks the object that is in the context as selected', () => {
+      const result = convertObjectsToSelectOptions(objects, 'name', 'id', 'field', { field: '123' })
+
+      expect(result).toEqual([
+        {
+          value: '',
+          text: 'Select a keyworker',
+          selected: false,
+        },
+        {
+          text: 'abc',
+          value: '123',
+          selected: true,
+        },
+        {
+          text: 'def',
+          value: '345',
+          selected: false,
         },
       ])
     })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -1,4 +1,4 @@
-import type { ErrorMessages, RadioItems } from 'approved-premises'
+import type { ErrorMessages, RadioItems, SelectOptions } from 'approved-premises'
 
 export const dateFieldValues = (fieldName: string, context: Record<string, unknown>, errors: ErrorMessages = {}) => {
   const errorClass = errors[fieldName] ? 'govuk-input--error' : ''
@@ -35,6 +35,32 @@ export const convertObjectsToRadioItems = (
       checked: context[fieldName] === item[valueKey],
     }
   })
+}
+
+export const convertObjectsToSelectOptions = (
+  items: Array<Record<string, string>>,
+  textKey: string,
+  valueKey: string,
+  fieldName: string,
+  context: Record<string, unknown>,
+): Array<SelectOptions> => {
+  const options = [
+    {
+      value: '',
+      text: 'Select a keyworker',
+      selected: !context[fieldName] || context[fieldName] === '',
+    },
+  ]
+
+  items.forEach(item => {
+    options.push({
+      text: item[textKey],
+      value: item[valueKey],
+      selected: context[fieldName] === item[valueKey],
+    })
+  })
+
+  return options
 }
 
 export function convertKeyValuePairToRadioItems<T>(object: T, checkedItem: string): Array<RadioItems> {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -7,7 +7,7 @@ import * as pathModule from 'path'
 
 import type { ErrorMessages } from 'approved-premises'
 import { initialiseName, formatDateString } from './utils'
-import { dateFieldValues, convertObjectsToRadioItems } from './formUtils'
+import { dateFieldValues, convertObjectsToRadioItems, convertObjectsToSelectOptions } from './formUtils'
 import bookingActions from './bookingUtils'
 
 import managePaths from '../paths/manage'
@@ -64,6 +64,18 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
       fieldName: string,
     ) {
       return convertObjectsToRadioItems(items, textKey, valueKey, fieldName, this.ctx)
+    },
+  )
+
+  njkEnv.addGlobal(
+    'convertObjectsToSelectOptions',
+    function sendContextConvertObjectsToSelectOptions(
+      items: Array<Record<string, string>>,
+      textKey: string,
+      valueKey: string,
+      fieldName: string,
+    ) {
+      return convertObjectsToSelectOptions(items, textKey, valueKey, fieldName, this.ctx)
     },
   )
 

--- a/server/views/bookings/new.njk
+++ b/server/views/bookings/new.njk
@@ -89,25 +89,7 @@
                     classes: "govuk-input--width-20",
                     id: "keyWorkerId",
                     name: "keyWorkerId",
-                    items: [
-                        {
-                        value: "",
-                        text: "Select a keyworker",
-                        selected: keyWorkerId === ''
-                        },
-                        {
-                        value: "bda42ec2-2435-47da-bb7f-54e90eda78b2",
-                        text: "George Frank"
-                        },
-                        {
-                        value: "55126a32-0d27-4044-bc4e-e21c01632e56",
-                        text: "Alex Evans"
-                        },
-                        {
-                        value: "cddb4be3-f0ef-4889-b987-61e1777ab17c",
-                        text: "Jo Longford"
-                        }
-                    ],
+                    items: convertObjectsToSelectOptions(keyWorkers, 'name', 'id', 'keyWorkerId'),
                     errorMessage: errors.keyWorkerId
                 }) }}
 

--- a/wiremock/referenceDataStubs.ts
+++ b/wiremock/referenceDataStubs.ts
@@ -3,6 +3,7 @@ import moveOnCategoriesJson from './stubs/move-on-categories.json'
 import destinationProvidersJson from './stubs/destination-providers.json'
 import cancellationReasonsJson from './stubs/cancellation-reasons.json'
 import lostBedReasonsJson from './stubs/lost-bed-reasons.json'
+import keyWorkersJson from './stubs/keyworkers.json'
 
 const departureReasons = {
   request: {
@@ -74,4 +75,18 @@ const lostBedReasons = {
   },
 }
 
-export { departureReasons, moveOnCategories, destinationProviders, cancellationReasons, lostBedReasons }
+const keyWorkers = {
+  request: {
+    method: 'GET',
+    url: '/reference-data/key-workers',
+  },
+  response: {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+    },
+    jsonBody: keyWorkersJson,
+  },
+}
+
+export { departureReasons, moveOnCategories, destinationProviders, cancellationReasons, lostBedReasons, keyWorkers }

--- a/wiremock/stubs/keyworkers.json
+++ b/wiremock/stubs/keyworkers.json
@@ -1,0 +1,22 @@
+[
+  { "id": "f83abc97-c1df-4957-9682-612910125e57", "name": "Kelby Tabert", "isActive": true },
+  { "id": "6ef5d312-d159-4c61-bdec-92e48c8e8465", "name": "Wilfred Jepp", "isActive": true },
+  { "id": "c1becf23-8d20-4274-ba0e-91b3282e2c13", "name": "Rozelle Spendley", "isActive": true },
+  { "id": "acd9775d-308b-4401-97ec-1a5e996c0a07", "name": "Vanna Theuss", "isActive": true },
+  { "id": "6294507a-9443-485f-8294-ff07c1112f8c", "name": "Venessa McDermott", "isActive": true },
+  { "id": "a854e768-5698-4cfd-a4c5-f8a532bd4211", "name": "Taylor Kuphal", "isActive": true },
+  { "id": "f63a93c6-f6cc-493b-9d21-475f2639cf79", "name": "Mitch Medhurst", "isActive": true },
+  { "id": "654700e9-cfdc-4d5f-8de6-78ee3e125bc3", "name": "Daniella Medhurst V", "isActive": true },
+  { "id": "68484042-5778-4332-a0e8-059f62def3d4", "name": "Oswaldo Collins II", "isActive": true },
+  { "id": "9ba538d0-3066-439f-975d-6635af3f6f63", "name": "Mario Schmidt IV", "isActive": true },
+  { "id": "720cbcb6-2eb8-4f10-90a0-a8e8589a6efc", "name": "Reuben Konopelski", "isActive": true },
+  { "id": "a741d453-796d-476b-8d27-5b4a1d1e0d09", "name": "Denae Spencer", "isActive": true },
+  { "id": "99f6122d-a0c4-47eb-8eb0-43809a384eaa", "name": "Mozella Russel", "isActive": true },
+  { "id": "0e67af2b-c93e-48a1-9dc5-2a08e0d4d82c", "name": "Willene Towne", "isActive": true },
+  { "id": "0e29769d-f883-4b6b-85de-1b014fc125df", "name": "Randell Adams DDS", "isActive": false },
+  { "id": "7b41acdd-1e66-4cfc-91e1-47ab40a70694", "name": "Dr. Alexander Gibson", "isActive": true },
+  { "id": "0cc91821-3a95-4cf5-bbdd-8d44124e01f3", "name": "Cammy McDermott", "isActive": true },
+  { "id": "1889b41b-0850-4fba-ac4a-f1bf07ae7201", "name": "Carmen Walter", "isActive": true },
+  { "id": "0895532a-6c62-462c-96e9-5b545d70310c", "name": "Van Batz", "isActive": true },
+  { "id": "6179471a-776d-4972-99c4-89c5679c4253", "name": "Dr. Benedict Kunde", "isActive": true }
+]


### PR DESCRIPTION
This removes the hardcoded keyworkers, and instead fetches them from the `/reference-data/key-workers` endpoint.